### PR TITLE
[Feat]New connection methods

### DIFF
--- a/Sources/PrivMXEndpointSwift/Core/Connection.swift
+++ b/Sources/PrivMXEndpointSwift/Core/Connection.swift
@@ -38,6 +38,38 @@ public class Connection{
 	internal var api: privmx.NativeConnectionWrapper
 	
 	/// Creates a new connection instance to PrivMX platform using a private key.
+	///
+	/// The path to the certificates must be set beforehand using `setCertsPath()`. This connection is used to interact with secured operations such as Inboxes, Threads, and Stores.
+	///
+	/// - Parameter userPrivKey: The user's private key in WIF format, required for authentication.
+	/// - Parameter solutionId: The ID of the Solution that the connection targets.
+	/// - Parameter bridgeUrl: The URL of PrivMX platform endpoint.
+	///
+	/// - Throws: `PrivMXEndpointError.failedConnecting` if establishing the connection fails.
+	///
+	/// - Returns: A `Connection` instance that can be used for further operations.
+	public static func connect(
+		userPrivKey: std.string,
+		solutionId: std.string,
+		bridgeUrl: std.string
+	) throws -> Connection{
+		let res = privmx.NativeConnectionWrapper.connect(userPrivKey,
+														 solutionId,
+														 bridgeUrl)
+		guard res.error.value == nil else {
+			throw PrivMXEndpointError.failedConnecting(res.error.value!)
+		}
+		guard let result = res.result.value else{
+			var err = privmx.InternalError()
+			err.name = "Value error"
+			err.description = "Unexpectedly received nil result"
+			throw PrivMXEndpointError.failedConnecting(err)
+		}
+		
+		return Connection(api:result.pointee)
+	}
+	
+	/// Creates a new connection instance to PrivMX platform using a private key.
     ///
     /// The path to the certificates must be set beforehand using `setCertsPath()`. This connection is used to interact with secured operations such as Inboxes, Threads, and Stores.
     ///
@@ -48,7 +80,8 @@ public class Connection{
     /// - Throws: `PrivMXEndpointError.failedConnecting` if establishing the connection fails.
     ///
     /// - Returns: A `Connection` instance that can be used for further operations.
-    public static func connect(
+	@available(*, deprecated, renamed: "connect(userPrivKey:solutionId:bridgeUrl:)")
+	public static func connect(
 		userPrivKey: std.string,
 		solutionId: std.string,
 		platformUrl: std.string
@@ -74,17 +107,47 @@ public class Connection{
     /// The path to the certificates must be set beforehand using `setCertsPath()`. This type of connection is primarily used for public operations, such as inbound Inbox traffic, where authentication is not required.
     ///
     /// - Parameter solutionId: The ID of the Solution that the connection targets.
-    /// - Parameter platformUrl: The URL of PrivMX platform endpoint.
+    /// - Parameter bridgeUrl: The URL of PrivMX platform endpoint.
     ///
     /// - Throws: `PrivMXEndpointError.failedConnecting` if establishing the connection fails.
     ///
     /// - Returns: A public `Connection` instance that can be used for non-authenticated operations.
     public static func connectPublic(
 		solutionId: std.string,
+		bridgeUrl: std.string
+	) throws -> Connection{
+		let res = privmx.NativeConnectionWrapper.connectPublic(solutionId,
+															   bridgeUrl)
+		guard res.error.value == nil else {
+			throw PrivMXEndpointError.failedConnecting(res.error.value!)
+		}
+		guard let result = res.result.value else{
+			var err = privmx.InternalError()
+			err.name = "Value error"
+			err.description = "Unexpectedly received nil result"
+			throw PrivMXEndpointError.failedConnecting(err)
+		}
+		
+		return Connection(api:result.pointee)
+	}
+	
+	/// Creates a new public connection to PrivMX platform.
+    ///
+    /// The path to the certificates must be set beforehand using `setCertsPath()`. This type of connection is primarily used for public operations, such as inbound Inbox traffic, where authentication is not required.
+    ///
+    /// - Parameter solutionId: The ID of the Solution that the connection targets.
+    /// - Parameter platformUrl: The URL of PrivMX platform endpoint.
+    ///
+    /// - Throws: `PrivMXEndpointError.failedConnecting` if establishing the connection fails.
+    ///
+    /// - Returns: A public `Connection` instance that can be used for non-authenticated operations.
+	@available(*, deprecated, renamed: "connectPublic(solutionId:bridgeUrl:)")
+    public static func connectPublic(
+		solutionId: std.string,
 		platformUrl: std.string
 	) throws -> Connection{
 		let res = privmx.NativeConnectionWrapper.platformConnectPublic(solutionId,
-																		  platformUrl)
+																	   platformUrl)
 		guard res.error.value == nil else {
 			throw PrivMXEndpointError.failedConnecting(res.error.value!)
 		}

--- a/Sources/PrivMXEndpointSwiftNative/NativeConnectionWrapper.cpp
+++ b/Sources/PrivMXEndpointSwiftNative/NativeConnectionWrapper.cpp
@@ -28,10 +28,16 @@ NativeConnectionWrapper::NativeConnectionWrapper(std::shared_ptr<core::Connectio
 ResultWithError<std::shared_ptr<NativeConnectionWrapper>> NativeConnectionWrapper::platformConnect(const std::string &userPrivKey,
 																								   const std::string &solutionId,
 																								   const std::string &platformUrl){
+	return connect(userPrivKey, solutionId, platformUrl);
+}
+
+ResultWithError<std::shared_ptr<NativeConnectionWrapper>> NativeConnectionWrapper::connect(const std::string &userPrivKey,
+																						   const std::string &solutionId,
+																						   const std::string &platformUrl){
 	ResultWithError<std::shared_ptr<NativeConnectionWrapper>> res;
 	std::shared_ptr<NativeConnectionWrapper> x;
 	try{
-		auto conn = NativeConnectionWrapper(std::make_shared<core::Connection>(core::Connection::platformConnect(userPrivKey,
+		auto conn = NativeConnectionWrapper(std::make_shared<core::Connection>(core::Connection::connect(userPrivKey,
 																												 solutionId,
 																												 platformUrl)));
 		res.result = std::make_shared<NativeConnectionWrapper>(conn);
@@ -57,12 +63,16 @@ ResultWithError<std::shared_ptr<NativeConnectionWrapper>> NativeConnectionWrappe
 }
 
 ResultWithError<std::shared_ptr<NativeConnectionWrapper>> NativeConnectionWrapper::platformConnectPublic(const std::string &solutionId,
-																											const std::string &platformUrl){
+																										 const std::string &platformUrl){
+	return connectPublic(solutionId, platformUrl);
+}
+ResultWithError<std::shared_ptr<NativeConnectionWrapper>> NativeConnectionWrapper::connectPublic(const std::string &solutionId,
+																								 const std::string &platformUrl){
 	ResultWithError<std::shared_ptr<NativeConnectionWrapper>> res;
 	std::shared_ptr<NativeConnectionWrapper> x;
 	try{
-		auto conn = NativeConnectionWrapper(std::make_shared<core::Connection>(core::Connection::platformConnectPublic(solutionId,
-																													   platformUrl)));
+		auto conn = NativeConnectionWrapper(std::make_shared<core::Connection>(core::Connection::connectPublic(solutionId,
+																											   platformUrl)));
 		res.result = std::make_shared<NativeConnectionWrapper>(conn);
 	}catch(core::Exception& err){
 		res.error = {

--- a/Sources/PrivMXEndpointSwiftNative/include/NativeConnectionWrapper.hpp
+++ b/Sources/PrivMXEndpointSwiftNative/include/NativeConnectionWrapper.hpp
@@ -37,6 +37,20 @@ public:
 	 * @return Shared pointer to a Connection object, wrapped in the `ResultWithError` for error handling.
 	 *
 	 */
+	static ResultWithError<std::shared_ptr<NativeConnectionWrapper>> connect(const std::string& userPrivKey,
+																			 const std::string& solutionId,
+																			 const std::string& bridgeUrl);
+	/**
+	 * Connects to the PrivMX Bridge server.
+	 *
+	 * @param userPrivKey user's private key
+	 * @param solutionId ID of the Solution
+	 * @param platformUrl Platform's Endpoint URL
+	 *
+	 * @return Shared pointer to a Connection object, wrapped in the `ResultWithError` for error handling.
+	 *
+	 */
+	[[deprecated]]
 	static ResultWithError<std::shared_ptr<NativeConnectionWrapper>> platformConnect(const std::string& userPrivKey,
 																					 const std::string& solutionId,
 																					 const std::string& platformUrl);
@@ -50,8 +64,20 @@ public:
 	 * @return Shared pointer to a Connection object, wrapped in `ResultWithError` for error handling.
 	 *
 	 */
+	static ResultWithError<std::shared_ptr<NativeConnectionWrapper>> connectPublic(const std::string& solutionId,
+																				   const std::string& bridgeUrl);
+	/**
+	 * Connects to the PrivMX Bridge Server as a guest user.
+	 *
+	 * @param solutionId ID of the Solution
+	 * @param platformUrl Platform's Endpoint URL
+	 *
+	 * @return Shared pointer to a Connection object, wrapped in `ResultWithError` for error handling.
+	 *
+	 */
+	[[deprecated]]
 	static ResultWithError<std::shared_ptr<NativeConnectionWrapper>> platformConnectPublic(const std::string& solutionId,
-																					 const std::string& platformUrl);
+																						   const std::string& platformUrl);
 	
 	/**
 	 * Sets the path to.pem  file with certificates.


### PR DESCRIPTION
## ADDITIONS
- `NativeConnectionWrapper::connect()`
- `NativeConnectionWrapper::conectPublic()`
- `Connection.connect(userPrivKey:solutionId:bridgeUrl:)`
- `Connection.connectPublic(solutionId:bridgeUrl:)`
   
## MODIFICATIONS
- Deprecated `platformConnect()` and `platformConnectPublic()` in NativeConnectionWrapper
- Deprecated `connect(userPrivKey:solutionId:platformUrl:)` and `connectPublic(solutionId:platformUrl:)` in Connection

Closes #5 