### PR TITLE
Feat: implement container policies

### DIFF
--- a/Sources/PrivMXEndpointSwift/Inboxes/InboxApi.swift
+++ b/Sources/PrivMXEndpointSwift/Inboxes/InboxApi.swift
@@ -75,7 +75,8 @@ public class InboxApi{
 		managers: privmx.UserWithPubKeyVector,
 		publicMeta: privmx.endpoint.core.Buffer,
 		privateMeta: privmx.endpoint.core.Buffer,
-		filesConfig: privmx.endpoint.inbox.FilesConfig?
+		filesConfig: privmx.endpoint.inbox.FilesConfig?,
+		policies: privmx.endpoint.core.ContainerPolicyWithoutItem? = nil
 	) throws -> std.string {
 		
 		var optFilesConfig = privmx.OptionalInboxFilesConfig()
@@ -84,12 +85,18 @@ public class InboxApi{
 			optFilesConfig = privmx.makeOptional(filesConfig)
 		}
 		
+		var optPolicies = privmx.OptionalContainerPolicyWithoutItem()
+		if let policies{
+			optPolicies = privmx.makeOptional(policies)
+		}
+		
 		let res = api.createInbox(contextId,
 								  users,
 								  managers,
 								  publicMeta,
 								  privateMeta,
-								  optFilesConfig)
+								  optFilesConfig,
+								  optPolicies)
 		
 		guard res.error.value == nil else {
 			throw PrivMXEndpointError.failedCreatingInbox(res.error.value!)
@@ -126,14 +133,19 @@ public class InboxApi{
 		filesConfig: privmx.endpoint.inbox.FilesConfig?,
 		version: Int64,
 		force: Bool,
-		forceGenerateNewKey: Bool
+		forceGenerateNewKey: Bool,
+		policies: privmx.endpoint.core.ContainerPolicyWithoutItem? = nil
 	) throws -> Void {
-		
 		
 		var optFilesConfig = privmx.OptionalInboxFilesConfig()
 		
 		if let filesConfig{
 			optFilesConfig = privmx.makeOptional(filesConfig)
+		}
+		
+		var optPolicies = privmx.OptionalContainerPolicyWithoutItem()
+		if let policies{
+			optPolicies = privmx.makeOptional(policies)
 		}
 		
 		let res = api.updateInbox(inboxId,
@@ -144,7 +156,8 @@ public class InboxApi{
 								  optFilesConfig,
 								  version,
 								  force,
-								  forceGenerateNewKey)
+								  forceGenerateNewKey,
+								  optPolicies)
 		
 		guard res.error.value == nil else {
 			throw PrivMXEndpointError.failedUpdatingInbox(res.error.value!)

--- a/Sources/PrivMXEndpointSwift/Inboxes/InboxApi.swift
+++ b/Sources/PrivMXEndpointSwift/Inboxes/InboxApi.swift
@@ -57,6 +57,8 @@ public class InboxApi{
 	}
 	
 	/// Creates a new Inbox in the specified context.
+	///
+	/// If `policies` argument is set to `nil`, the default policies will be applied.
     ///
     /// - Parameters:
     ///   - contextId: The ID of the context where the Inbox should be created.
@@ -65,6 +67,7 @@ public class InboxApi{
     ///   - publicMeta: Public metadata that is not encrypted.
     ///   - privateMeta: Private metadata that is encrypted.
     ///   - filesConfig: An optional configuration for file storage.
+	///   - policies: A set of policies for the Container.
     ///
     /// - Throws: `PrivMXEndpointError.failedCreatingInbox` if Inbox creation fails.
     ///
@@ -111,6 +114,8 @@ public class InboxApi{
 	}
 	
 	/// Updates an existing Inbox with new metadata and configuration.
+	///
+	/// If `policies` argument is set to `nil`, the default policies will be applied.
     ///
     /// - Parameters:
     ///   - inboxId: The ID of the Inbox to be updated.
@@ -122,6 +127,7 @@ public class InboxApi{
     ///   - version: The current version of the Inbox for version control.
     ///   - force: Whether to force the update, ignoring version control.
     ///   - forceGenerateNewKey: Whether to force regeneration of a new key for the Inbox.
+	///   - policies: New set of policies for the Container.
     ///
     /// - Throws: `PrivMXEndpointError.failedUpdatingInbox` if the update process fails.
     public func updateInbox(

--- a/Sources/PrivMXEndpointSwift/Stores/StoreApi.swift
+++ b/Sources/PrivMXEndpointSwift/Stores/StoreApi.swift
@@ -122,13 +122,21 @@ public class StoreApi{
 		users: privmx.UserWithPubKeyVector,
 		managers: privmx.UserWithPubKeyVector,
 		publicMeta: privmx.endpoint.core.Buffer,
-		privateMeta: privmx.endpoint.core.Buffer
+		privateMeta: privmx.endpoint.core.Buffer,
+		policies: privmx.endpoint.core.ContainerPolicy? = nil
 	) throws -> std.string{
-		let res = api.createStore(contextId, 
+		
+		var optPolicies = privmx.OptionalContainerPolicy()
+		if let policies{
+			optPolicies = privmx.makeOptional(policies)
+		}
+		
+		let res = api.createStore(contextId,
 								  users, 
 								  managers,
 								  publicMeta,
-								  privateMeta)
+								  privateMeta,
+								  optPolicies)
 		guard res.error.value == nil else {
 			throw PrivMXEndpointError.failedCreatingStore(res.error.value!)
 		}
@@ -164,8 +172,15 @@ public class StoreApi{
 		publicMeta: privmx.endpoint.core.Buffer,
 		privateMeta: privmx.endpoint.core.Buffer,
 		force: Bool,
-		forceGenerateNewKey: Bool
+		forceGenerateNewKey: Bool,
+		policies: privmx.endpoint.core.ContainerPolicy? = nil
 	) throws -> Void {
+		
+		var optPolicies = privmx.OptionalContainerPolicy()
+		if let policies{
+			optPolicies = privmx.makeOptional(policies)
+		}
+		
 		let res = api.updateStore(storeId,
 								  users,
 								  managers,
@@ -173,7 +188,8 @@ public class StoreApi{
 								  privateMeta,
 								  version,
 								  force,
-								  forceGenerateNewKey)
+								  forceGenerateNewKey,
+								  optPolicies)
 		guard res.error.value == nil else {
 			throw PrivMXEndpointError.failedUpdatingStore(res.error.value!)
 		}

--- a/Sources/PrivMXEndpointSwift/Stores/StoreApi.swift
+++ b/Sources/PrivMXEndpointSwift/Stores/StoreApi.swift
@@ -106,6 +106,8 @@ public class StoreApi{
 	/// Creates a new Store within a specified Context.
     ///
     /// This method creates a new Store with specified users and managers. Note that managers must be added as users to gain access to the Store.
+	///
+	/// If `policies` argument is set to `nil`, the default policies will be applied.
     ///
     /// - Parameters:
     ///   - contextId: The Context in which the Store should be created.
@@ -113,6 +115,7 @@ public class StoreApi{
     ///   - managers: A vector of managers responsible for the Store.
     ///   - publicMeta: Public metadata for the Store, which will not be encrypted.
     ///   - privateMeta: Private metadata for the Store, which will be encrypted.
+	///   - policies: A set of policies for the Container.
     ///
     /// - Throws: `PrivMXEndpointError.failedCreatingStore` if Store creation fails.
     ///
@@ -152,6 +155,8 @@ public class StoreApi{
 	/// Updates an existing Store.
     ///
     /// The provided values will override the existing ones. You can also force regeneration of the Store's key if needed.
+	///
+	/// If `policies` argument is set to `nil`, the default policies will be applied.
     ///
     /// - Parameters:
     ///   - storeId: The unique identifier of the Store to be updated.
@@ -162,6 +167,7 @@ public class StoreApi{
     ///   - privateMeta: New private metadata for the Store, which will be encrypted.
     ///   - force: Whether to force the update, bypassing version control.
     ///   - forceGenerateNewKey: Whether to generate a new key for the Store.
+	///   - policies: New set of policies for the Container.
     ///
     /// - Throws: `PrivMXEndpointError.failedUpdatingStore` if updating the Store fails.
     public func updateStore(

--- a/Sources/PrivMXEndpointSwift/Threads/ThreadApi.swift
+++ b/Sources/PrivMXEndpointSwift/Threads/ThreadApi.swift
@@ -68,13 +68,21 @@ public class ThreadApi{
 		users: privmx.UserWithPubKeyVector,
 		managers: privmx.UserWithPubKeyVector,
 		publicMeta: privmx.endpoint.core.Buffer,
-		privateMeta: privmx.endpoint.core.Buffer
+		privateMeta: privmx.endpoint.core.Buffer,
+		policies: privmx.endpoint.core.ContainerPolicy? = nil
 	)throws -> std.string {
+		
+		var optPolicies = privmx.OptionalContainerPolicy()
+		if let policies{
+			optPolicies = privmx.makeOptional(policies)
+		}
+		
 		let res = api.createThread(contextId,
 								   users,
 								   managers,
 								   publicMeta,
-								   privateMeta)
+								   privateMeta,
+								   optPolicies)
 		guard res.error.value == nil else {
 			throw PrivMXEndpointError.failedCreatingThread(res.error.value!)
 		}
@@ -134,8 +142,15 @@ public class ThreadApi{
 		publicMeta: privmx.endpoint.core.Buffer,
 		privateMeta: privmx.endpoint.core.Buffer,
 		force: Bool,
-		forceGenerateNewKey: Bool
+		forceGenerateNewKey: Bool,
+		policies: privmx.endpoint.core.ContainerPolicy? = nil
 	) throws -> Void {
+		
+		var optPolicies = privmx.OptionalContainerPolicy()
+		if let policies{
+			optPolicies = privmx.makeOptional(policies)
+		}
+		
 		let res = api.updateThread(threadId,
 								   users,
 								   managers,
@@ -143,7 +158,8 @@ public class ThreadApi{
 								   privateMeta,
 								   version,
 								   force,
-								   forceGenerateNewKey)
+								   forceGenerateNewKey,
+								   optPolicies)
 		guard res.error.value == nil else {
 			throw PrivMXEndpointError.failedUpdatingThread(res.error.value!)
 		}

--- a/Sources/PrivMXEndpointSwift/Threads/ThreadApi.swift
+++ b/Sources/PrivMXEndpointSwift/Threads/ThreadApi.swift
@@ -53,12 +53,15 @@ public class ThreadApi{
 	///
 	/// This method creates a new Thread in the specified context, assigning users and managers to it. Note that managers must be added explicitly as users to access the Thread.
 	///
+	/// If `policies` argument is set to `nil`, the default policies will be applied.
+	///
 	/// - Parameters:
 	///   - contextId: The context in which the Thread should be created.
 	///   - users: A vector of users who will have access to the Thread.
 	///   - managers: A vector of managers responsible for the Thread.
 	///   - publicMeta: Public metadata for the Thread, which will not be encrypted.
 	///   - privateMeta: Private metadata for the Thread, which will be encrypted.
+	///   - policies: A set of policies for the Container.
 	///
 	/// - Throws: `PrivMXEndpointError.failedCreatingThread` if the Thread creation fails.
 	///
@@ -123,6 +126,8 @@ public class ThreadApi{
 	///
 	/// This method updates the metadata, users, and managers of a Thread. The update can be forced, and a new key can be generated if needed.
 	///
+	/// If `policies` argument is set to `nil`, the default policies will be applied.
+	///
 	/// - Parameters:
 	///   - threadId: The unique identifier of the Thread to be updated.
 	///   - version: The current version of the Thread to ensure version consistency.
@@ -132,6 +137,7 @@ public class ThreadApi{
 	///   - privateMeta: New private metadata for the Thread, which will be encrypted.
 	///   - force: Whether to force the update, bypassing version control.
 	///   - forceGenerateNewKey: Whether to generate a new key for the Thread.
+	///   - policies: A new set of policies for the Container.
 	///
 	/// - Throws: `PrivMXEndpointError.failedUpdatingThread` if the update process fails.
 	public func updateThread(

--- a/Sources/PrivMXEndpointSwiftNative/NativeInboxApiWrapper.cpp
+++ b/Sources/PrivMXEndpointSwiftNative/NativeInboxApiWrapper.cpp
@@ -52,7 +52,8 @@ ResultWithError<std::string> NativeInboxApiWrapper::createInbox(const std::strin
 																const UserWithPubKeyVector& managers,
 																const endpoint::core::Buffer& publicMeta,
 																const endpoint::core::Buffer& privateMeta,
-																const OptionalInboxFilesConfig& filesConfig) {
+																const OptionalInboxFilesConfig& filesConfig,
+																const OptionalContainerPolicyWithoutItem& policies) {
 	ResultWithError<std::string> res;
 	try {
 		res.result = getapi()->createInbox(contextId,
@@ -90,7 +91,8 @@ ResultWithError<nullptr_t> NativeInboxApiWrapper::updateInbox(const std::string&
 															  const OptionalInboxFilesConfig& filesConfig,
 															  const int64_t version,
 															  const bool force,
-															  const bool forceGenerateNewKey){
+															  const bool forceGenerateNewKey,
+															  const OptionalContainerPolicyWithoutItem& policies){
 	ResultWithError<nullptr_t> res;
 	try {
 		getapi()->updateInbox(inboxId,
@@ -101,7 +103,8 @@ ResultWithError<nullptr_t> NativeInboxApiWrapper::updateInbox(const std::string&
 							  filesConfig,
 							  version,
 							  force,
-							  forceGenerateNewKey);
+							  forceGenerateNewKey,
+							  policies);
 		}catch(core::Exception& err){
 		res.error = {
 			.name = err.getName(),

--- a/Sources/PrivMXEndpointSwiftNative/NativeStoreApiWrapper.cpp
+++ b/Sources/PrivMXEndpointSwiftNative/NativeStoreApiWrapper.cpp
@@ -99,10 +99,16 @@ ResultWithError<std::string> NativeStoreApiWrapper::createStore(const std::strin
 																const UserWithPubKeyVector& users,
 																const UserWithPubKeyVector& managers,
 																const core::Buffer& publicMeta,
-																const core::Buffer& privateMeta){
+																const core::Buffer& privateMeta,
+																const OptionalContainerPolicy& policies){
 	ResultWithError<std::string> res;
 	try{
-		res.result = getapi()->createStore(contextId, users, managers, publicMeta,privateMeta);
+		res.result = getapi()->createStore(contextId,
+										   users,
+										   managers,
+										   publicMeta,
+										   privateMeta,
+										   policies);
 		}catch(core::Exception& err){
 		res.error = {
 			.name = err.getName(),
@@ -131,7 +137,8 @@ ResultWithError<std::nullptr_t> NativeStoreApiWrapper::updateStore(const std::st
 																   const core::Buffer& privateMeta,
 																   const int64_t version,
 																   const bool force,
-																   const bool forceGenerateNewKey){
+																   const bool forceGenerateNewKey,
+																   const OptionalContainerPolicy& policies){
 	ResultWithError<std::nullptr_t> res;
 	try{
 		getapi()->updateStore(storeId,
@@ -141,7 +148,8 @@ ResultWithError<std::nullptr_t> NativeStoreApiWrapper::updateStore(const std::st
 							  privateMeta,
 							  version,
 							  force,
-							  forceGenerateNewKey);
+							  forceGenerateNewKey,
+							  policies);
 		}catch(core::Exception& err){
 		res.error = {
 			.name = err.getName(),

--- a/Sources/PrivMXEndpointSwiftNative/NativeThreadApiWrapper.cpp
+++ b/Sources/PrivMXEndpointSwiftNative/NativeThreadApiWrapper.cpp
@@ -47,14 +47,16 @@ ResultWithError<std::string> NativeThreadApiWrapper::createThread(const std::str
 																  const UserWithPubKeyVector& users,
 																  const UserWithPubKeyVector& managers,
 																  const core::Buffer& publicMeta,
-																  const core::Buffer& privateMeta){
+																  const core::Buffer& privateMeta,
+																  const OptionalContainerPolicy& policies){
 	ResultWithError<std::string> res;
 	try {
 		res.result = getapi()->createThread(contextId,
 											users,
 											managers,
 											publicMeta,
-											privateMeta);
+											privateMeta,
+											policies);
 		}catch(core::Exception& err){
 		res.error = {
 			.name = err.getName(),
@@ -266,7 +268,8 @@ ResultWithError<std::nullptr_t> NativeThreadApiWrapper::updateThread(const std::
 																	 const core::Buffer& privateMeta,
 																	 const int64_t version,
 																	 const bool force,
-																	 const bool generateNewKeyId){
+																	 const bool generateNewKeyId,
+																	 const OptionalContainerPolicy& policies){
 	ResultWithError<std::nullptr_t> res;
 	try {
 		getapi()->updateThread(threadId,
@@ -276,7 +279,8 @@ ResultWithError<std::nullptr_t> NativeThreadApiWrapper::updateThread(const std::
 							   privateMeta,
 							   version,
 							   force,
-							   generateNewKeyId);
+							   generateNewKeyId,
+							   policies);
 		}catch(core::Exception& err){
 		res.error = {
 			.name = err.getName(),

--- a/Sources/PrivMXEndpointSwiftNative/include/NativeInboxApiWrapper.hpp
+++ b/Sources/PrivMXEndpointSwiftNative/include/NativeInboxApiWrapper.hpp
@@ -35,13 +35,15 @@ public:
 	 * @param privateMeta private (encrypted) meta data
 	 * @param filesConfig struct to override default file configuration
 	 * @return string inbox ID
+	 * @param policies Inbox policies
 	 */
 	ResultWithError<std::string> createInbox(const std::string& contextId,
 											 const UserWithPubKeyVector& users,
 											 const UserWithPubKeyVector& managers,
 											 const endpoint::core::Buffer& publicMeta,
 											 const endpoint::core::Buffer& privateMeta,
-											 const OptionalInboxFilesConfig& filesConfig);
+											 const OptionalInboxFilesConfig& filesConfig,
+											 const OptionalContainerPolicyWithoutItem& policies);
 
 	/**
 	 * Updates an existing Inbox.
@@ -56,6 +58,7 @@ public:
 	 * @param version current version of the updated Inbox
 	 * @param force force update (without checking version)
 	 * @param forceGenerateNewKey force to renenerate a key for the Inbox
+	 * @param policies Inbox policies
 	 */
 	ResultWithError<nullptr_t> updateInbox(const std::string& inboxId,
 										   const UserWithPubKeyVector& users,
@@ -65,7 +68,8 @@ public:
 										   const OptionalInboxFilesConfig& filesConfig,
 										   const int64_t version,
 										   const bool force,
-										   const bool forceGenerateNewKey);
+										   const bool forceGenerateNewKey,
+										   const OptionalContainerPolicyWithoutItem& policies = std::nullopt);
 	
 	/**
 	 * Gets a single Inbox by given Inbox ID.

--- a/Sources/PrivMXEndpointSwiftNative/include/NativeStoreApiWrapper.hpp
+++ b/Sources/PrivMXEndpointSwiftNative/include/NativeStoreApiWrapper.hpp
@@ -60,7 +60,9 @@ public:
 	 * @param contextId : `const std::string&` — in which Context should the Store be created
 	 * @param users : `const UserWithPubKeyVector&` — who can access the Store
 	 * @param managers : `const UserWithPubKeyVector&` — who can manage the Store
-	 * @param name : `const endpoint::core::Buffer&` — the name of the Store
+	 * @param publicMeta public (unencrypted) metadata
+	 * @param privateMeta private (encrypted) metadata
+	 * @param policies additional container access policies
 	 *
 	 * @return Id of the newly created Store wrapped in a`ResultWithError` structure for error handling.
 	 */
@@ -68,7 +70,8 @@ public:
 											 const UserWithPubKeyVector& users,
 											 const UserWithPubKeyVector& managers,
 											 const endpoint::core::Buffer& publicMeta,
-											 const endpoint::core::Buffer& privateMeta);
+											 const endpoint::core::Buffer& privateMeta,
+											 const OptionalContainerPolicy& policies = std::nullopt);
 	
 	/**
 	 * Deletes a Store.
@@ -87,12 +90,12 @@ public:
 	 * @param storeId : `const std::string&` — which Store is to be updated
 	 * @param users : `const UserWithPubKeyVector&` — who can access the Store
 	 * @param managers : `const UserWithPubKeyVector&` — who can manage the Store
-	 * @param title : `const std::string&` — the title of the Store
+	 * @param publicMeta public (unencrypted) metadata
+	 * @param privateMeta private (encrypted) metadata
 	 * @param version : `const int64_t` — current version of the Store
 	 * @param force : `const bool` — force the update by disregarding the cersion check
-	 * @param generateNewKeyId : `const bool` — force regeneration of new keyId for Store
-	 * @param accessToOldDataForNewUsers : `const bool` — placeholder parameter (does nothing for now)
-	 *
+	 * @param forceGenerateNewKey force to regenerate a key for the Store
+	 * @param policies additional container access policies
 	 *
 	 * @return `ResultWithError` structure for error handling.
 	 */
@@ -103,7 +106,8 @@ public:
 												const endpoint::core::Buffer& privateMeta,
 												const int64_t version,
 												const bool force,
-												const bool forceGenerateNewKey);
+												const bool forceGenerateNewKey,
+												const OptionalContainerPolicy& = std::nullopt);
 	
 	/**
 	 * Retrieves information about a File

--- a/Sources/PrivMXEndpointSwiftNative/include/NativeThreadApiWrapper.hpp
+++ b/Sources/PrivMXEndpointSwiftNative/include/NativeThreadApiWrapper.hpp
@@ -42,14 +42,15 @@ public:
 	 * @param users : `const UserWithPubKeyVector&` — who can access the Thread
 	 * @param managers : `const UserWithPubKeyVector&` — who can manage the thread
 	 * @param title : `const std::string&` — the title of the thread
-	 *
+	 * @param policies additional container access policies
 	 * @return Id of the newly created Thread wrapped in a`ResultWithError` structure for error handling.
 	 */
 	ResultWithError<std::string> createThread(const std::string& contextId,
 											  const UserWithPubKeyVector& users,
 											  const UserWithPubKeyVector& managers,
 											  const endpoint::core::Buffer& publicMeta,
-											  const endpoint::core::Buffer& privateMeta);
+											  const endpoint::core::Buffer& privateMeta,
+											  const OptionalContainerPolicy& policies = std::nullopt);
 	
 	/**
 	 * Retrieves information about a thread.
@@ -73,7 +74,7 @@ public:
 	 * @param force : `const bool` — force the update by disregarding the cersion check
 	 * @param generateNewKeyId : `const bool` — force regeneration of new keyId for Thread
 	 * @param accessToOldDataForNewUsers : `const bool` — placeholder parameter (does nothing for now)
-	 *
+	 * @param policies additional container access policies
 	 *
 	 * @return `ResultWithError` structure for error handling.
 	 */
@@ -84,7 +85,8 @@ public:
 												 const endpoint::core::Buffer& privateMeta,
 												 const int64_t version,
 												 const bool force,
-												 const bool forceGenerateNewKey);
+												 const bool forceGenerateNewKey,
+												 const OptionalContainerPolicy& policies = std::nullopt);
 	
 	/**
 	 * Deletes a Thread.

--- a/Sources/PrivMXEndpointSwiftNative/include/PrivMXUtils.hpp
+++ b/Sources/PrivMXEndpointSwiftNative/include/PrivMXUtils.hpp
@@ -108,22 +108,22 @@ static OptionalString makeOptional(const std::string& val){
 }
 
 /// Creates a C++ `std::optional` containing the provided `FilesConfig`
-static OptionalInboxFilesConfig makeOptional(const privmx::endpoint::inbox::FilesConfig& val){
+static OptionalInboxFilesConfig makeOptional(const endpoint::inbox::FilesConfig& val){
 	return std::make_optional(val);
 }
 
-/// Creates a C++ `std::optional` containing the provided `FilesConfig`
-static OptionalItemPolicy makeOptional(const privmx::endpoint::core::ItemPolicy& val){
+/// Creates a C++ `std::optional` containing the provided `ItemPolicy`
+static OptionalItemPolicy makeOptional(const endpoint::core::ItemPolicy& val){
 	return std::make_optional(val);
 }
 
-/// Creates a C++ `std::optional` containing the provided `FilesConfig`
-static OptionalContainerPolicy makeOptional(const privmx::endpoint::core::ContainerPolicy& val){
+/// Creates a C++ `std::optional` containing the provided `ContainerPolicy`
+static OptionalContainerPolicy makeOptional(const endpoint::core::ContainerPolicy& val){
 	return std::make_optional(val);
 }
 
-/// Creates a C++ `std::optional` containing the provided `FilesConfig`
-static OptionalContainerPolicyWithoutItem makeOptional(const privmx::endpoint::core::ContainerPolicyWithoutItem& val){
+/// Creates a C++ `std::optional` containing the provided `ContainerPolicyWithoutItem`
+static OptionalContainerPolicyWithoutItem makeOptional(const endpoint::core::ContainerPolicyWithoutItem& val){
 	return std::make_optional(val);
 }
 

--- a/Sources/PrivMXEndpointSwiftNative/include/PrivMXUtils.hpp
+++ b/Sources/PrivMXEndpointSwiftNative/include/PrivMXUtils.hpp
@@ -54,6 +54,10 @@ using UserWithPubKeyVector = std::vector<endpoint::core::UserWithPubKey>;
 
 using OptionalInboxFilesConfig = std::optional<endpoint::inbox::FilesConfig>;
 
+using OptionalItemPolicy = std::optional<endpoint::core::ItemPolicy>;
+using OptionalContainerPolicy = std::optional<endpoint::core::ContainerPolicy>;
+using OptionalContainerPolicyWithoutItem = std::optional<endpoint::core::ContainerPolicyWithoutItem>;
+
 using ContextList = endpoint::core::PagingList<endpoint::core::Context>;
 using ThreadList = endpoint::core::PagingList<endpoint::thread::Thread>;
 using MessageList = endpoint::core::PagingList<endpoint::thread::Message>;
@@ -105,6 +109,21 @@ static OptionalString makeOptional(const std::string& val){
 
 /// Creates a C++ `std::optional` containing the provided `FilesConfig`
 static OptionalInboxFilesConfig makeOptional(const privmx::endpoint::inbox::FilesConfig& val){
+	return std::make_optional(val);
+}
+
+/// Creates a C++ `std::optional` containing the provided `FilesConfig`
+static OptionalItemPolicy makeOptional(const privmx::endpoint::core::ItemPolicy& val){
+	return std::make_optional(val);
+}
+
+/// Creates a C++ `std::optional` containing the provided `FilesConfig`
+static OptionalContainerPolicy makeOptional(const privmx::endpoint::core::ContainerPolicy& val){
+	return std::make_optional(val);
+}
+
+/// Creates a C++ `std::optional` containing the provided `FilesConfig`
+static OptionalContainerPolicyWithoutItem makeOptional(const privmx::endpoint::core::ContainerPolicyWithoutItem& val){
 	return std::make_optional(val);
 }
 


### PR DESCRIPTION
closes #7 
## ADDITIONS
### PrivMXEndpointSwiftNative
- aliases for  optionals of policy structs
- makeOptional() overloads for the above structs

## MODIFICATIONS
### PrivMXEndpointSwiftNative
- new parameter in update and create methods for Containers; with a default value of std::nullopt
### PrivMXEndpointSwift
- new optional parameter in update and create methods for Containers, defaulting to `nil`