### PR TITLE
Feat: added missing updateFileMeta method to StoreApi

### DIFF
--- a/Sources/PrivMXEndpointSwift/Stores/StoreApi.swift
+++ b/Sources/PrivMXEndpointSwift/Stores/StoreApi.swift
@@ -364,6 +364,24 @@ public class StoreApi{
 		return result
 	}
 	
+	/// Updates the metadata of an existing File.
+	/// - Parameters:
+	///   - fileId: id of a File to be updated
+	///   - publicMeta: new public metadata
+	///   - privateMeta: new private metadata
+	///
+	/// - Throws: When an error occurs during updating metadata.
+	public func updateFileMeta(
+		fileId: std.string,
+		publicMeta:privmx.endpoint.core.Buffer,
+		privateMeta:privmx.endpoint.core.Buffer
+	) throws -> Void {
+		let res = api.updateFileMeta(fileId, publicMeta, privateMeta)
+		guard res.error.value == nil else {
+			throw PrivMXEndpointError.failedUpdatingFile(res.error.value!)
+		}
+	}
+	
 	/// Closes an open file handle.
     ///
     /// This method finalizes a file operation, such as writing or updating.

--- a/Sources/PrivMXEndpointSwiftNative/NativeStoreApiWrapper.cpp
+++ b/Sources/PrivMXEndpointSwiftNative/NativeStoreApiWrapper.cpp
@@ -278,6 +278,33 @@ ResultWithError<StoreFileHandle> NativeStoreApiWrapper::updateFile(const std::st
 	return res;
 }
 
+ResultWithError<std::nullptr_t> NativeStoreApiWrapper::updateFileMeta(const std::string& fileId,
+																 const core::Buffer& publicMeta,
+																 const core::Buffer& privateMeta){
+	ResultWithError<std::nullptr_t> res;
+	try{
+		getapi()->updateFileMeta(fileId, publicMeta, privateMeta);
+		} catch(core::Exception& err) {
+		res.error = {
+			.name = err.getName(),
+			.code = err.getCode(),
+			.description = err.getDescription(),
+			.message = err.what()
+		};
+	}catch (std::exception & err) {
+		res.error ={
+			.name = "std::Exception",
+			.message = err.what()
+		};
+	}catch (...) {
+		res.error ={
+			.name = "Unknown Exception",
+			.message = "Failed to work"
+		};
+	}
+	return res;
+}
+
 ResultWithError<StoreFileHandle> NativeStoreApiWrapper::openFile(const std::string& fileId){
 	ResultWithError<StoreFileHandle> res;
 	try{

--- a/Sources/PrivMXEndpointSwiftNative/include/NativeStoreApiWrapper.hpp
+++ b/Sources/PrivMXEndpointSwiftNative/include/NativeStoreApiWrapper.hpp
@@ -165,6 +165,16 @@ public:
 											  int64_t size);
 	
 	/**
+	 * Update metadata of an existing file in a Store.
+	 *
+	 * @param fileId ID of the file to update
+	 * @param publicMeta public file metadata
+	 * @param privateMeta private file metadata
+	 */
+	ResultWithError<std::nullptr_t> updateFileMeta(const std::string& fileId,
+												   const endpoint::core::Buffer& publicMeta,
+												   const endpoint::core::Buffer& privateMeta);
+	/**
 	 * Creates a new file handle for reading a File.
 	 *
 	 * @param fileId : `const std::string&` — which File should be opened


### PR DESCRIPTION
## Additions:
- `updateFileMeta()` in `NativeStoreApiWrapper`
- `updateFileMeta(fileId:publicMeta:privateMeta:)` in `StoreApi`