### PR TITLE
Feat: New generatePrivKey and derivePrivKey methods

### DIFF
--- a/Sources/PrivMXEndpointSwift/Crypto/CryptoApi.swift
+++ b/Sources/PrivMXEndpointSwift/Crypto/CryptoApi.swift
@@ -134,7 +134,43 @@ public class CryptoApi{
 	///   - `PrivMXEndpointError.failedGeneratingPrivKey` if the key generation fails, potentially due to a system error or invalid seed.
 	///
 	/// **Security Note:** Private keys should be stored securely, ideally in an encrypted keystore or hardware security module (HSM).
+	@available(*, deprecated, renamed: "generatePrivateKey2(password:salt:)")
 	public func generatePrivateKey(
+		randomSeed: std.string?
+	) throws -> std.string {
+		var bs = privmx.OptionalString()
+		
+		if let randomSeed{
+			bs = privmx.makeOptional(randomSeed)
+		}
+		let res = api.generatePrivateKey(bs)
+		guard res.error.value == nil else {
+			throw PrivMXEndpointError.failedGeneratingPrivKey(res.error.value!)
+		}
+		guard let result = res.result.value else {
+			var err = privmx.InternalError()
+			err.name = "Value error"
+			err.description = "Unexpectedly received nil result"
+			throw PrivMXEndpointError.failedGeneratingPrivKey(err)
+		}
+		return result
+	}
+	
+	/// Generates a new private key in WIF (Wallet Import Format).
+	///
+	/// The private key can be used for various cryptographic operations such as signing data, generating public keys, and encrypting sensitive information. You can optionally provide a seed to generate a deterministic key, or omit the seed to generate a random key. Here it can be used for identifying and authorizing User (after previous adding its Public Key to PrivMX Bridge)
+	///
+	/// **Use case:** Private keys are used in both asymmetric encryption and signing operations. This method is useful when you need a fresh key pair for a new user or system process.
+	///
+	/// - Parameter randomSeed: An optional seed to generate a deterministic private key. If `nil` is provided, a random key will be generated.
+	///
+	/// - Returns: The generated private key in WIF format.
+	///
+	/// - Throws:
+	///   - `PrivMXEndpointError.failedGeneratingPrivKey` if the key generation fails, potentially due to a system error or invalid seed.
+	///
+	/// **Security Note:** Private keys should be stored securely, ideally in an encrypted keystore or hardware security module (HSM).
+	public func generatePrivateKey2(
 		randomSeed: std.string?
 	) throws -> std.string {
 		var bs = privmx.OptionalString()
@@ -171,12 +207,46 @@ public class CryptoApi{
 	///   - `PrivMXEndpointError.failedGeneratingPrivKey` if the key derivation fails, such as when using invalid input or a weak password.
 	///
 	/// **Security Note:** Passwords should never be stored or transmitted in plain text. Ensure that the salt is unique and sufficiently random to prevent predictable key generation.
+	@available(*,deprecated,renamed: "derivePrivateKey2(password:salt:)")
 	public func derivePrivateKey(
 		password: std.string,
 		salt: std.string
 	) throws -> std.string{
 		
 		let res = api.derivePrivateKey(password, salt)
+		guard res.error.value == nil else {
+			throw PrivMXEndpointError.failedGeneratingPrivKey(res.error.value!)
+		}
+		guard let result = res.result.value else {
+			var err = privmx.InternalError()
+			err.name = "Value error"
+			err.description = "Unexpectedly received nil result"
+			throw PrivMXEndpointError.failedGeneratingPrivKey(err)
+		}
+		return result
+	}
+	/// Derives a private key from a given password and salt using a key derivation function.
+	///
+	/// This method generates a private key based on a user-provided password and salt. The combination of the two ensures that the key is unique for each user and is always generated deterministically, and the salt prevents dictionary attacks.
+	///
+	/// **Use case:** Useful in scenarios where users are authenticated via passwords, but cryptographic operations require a private key. By deriving the key from a password, you avoid directly storing or transferring the private key.
+	///
+	/// - Parameters:
+	///   - password: The base string (usually a user password) used for deriving the key.
+	///   - salt: The salt value that makes the derived key unique, even if the same password is used by multiple users.
+	///
+	/// - Returns: The derived private key in WIF format.
+	///
+	/// - Throws:
+	///   - `PrivMXEndpointError.failedGeneratingPrivKey` if the key derivation fails, such as when using invalid input or a weak password.
+	///
+	/// **Security Note:** Passwords should never be stored or transmitted in plain text. Ensure that the salt is unique and sufficiently random to prevent predictable key generation.
+	public func derivePrivateKey2(
+		password: std.string,
+		salt: std.string
+	) throws -> std.string{
+		
+		let res = api.derivePrivateKey2(password, salt)
 		guard res.error.value == nil else {
 			throw PrivMXEndpointError.failedGeneratingPrivKey(res.error.value!)
 		}

--- a/Sources/PrivMXEndpointSwiftNative/NativeCryptoApiWrapper.cpp
+++ b/Sources/PrivMXEndpointSwiftNative/NativeCryptoApiWrapper.cpp
@@ -72,6 +72,31 @@ ResultWithError<std::string> NativeCryptoApiWrapper::generatePrivateKey(const Op
 	return res;
 }
 
+ResultWithError<std::string> NativeCryptoApiWrapper::generatePrivateKey2(const OptionalString& randomSeed){
+	ResultWithError<std::string> res;
+	try {
+		res.result = getapi()->generatePrivateKey2(randomSeed);
+		}catch(core::Exception& err){
+		res.error = {
+			.name = err.getName(),
+			.code = err.getCode(),
+			.description = err.getDescription(),
+			.message = err.what()
+		};
+	}catch (std::exception & err) {
+		res.error ={
+			.name = "std::Exception",
+			.message = err.what()
+		};
+	}catch (...) {
+		res.error ={
+			.name = "Unknown Exception",
+			.message = "Failed to work"
+		};
+	}
+	return res;
+}
+
 ResultWithError<std::string> NativeCryptoApiWrapper::derivePublicKey(const std::string& privKey){
 	ResultWithError<std::string> res;
 	try {
@@ -209,6 +234,33 @@ ResultWithError<std::string> NativeCryptoApiWrapper::derivePrivateKey(const std:
 	ResultWithError<std::string> res;
 	try {
 		res.result = getapi()->derivePrivateKey(password,
+												salt);
+		}catch(core::Exception& err){
+		res.error = {
+			.name = err.getName(),
+			.code = err.getCode(),
+			.description = err.getDescription(),
+			.message = err.what()
+		};
+	}catch (std::exception & err) {
+		res.error ={
+			.name = "std::Exception",
+			.message = err.what()
+		};
+	}catch (...) {
+		res.error ={
+			.name = "Unknown Exception",
+			.message = "Failed to work"
+		};
+	}
+	return res;
+}
+
+ResultWithError<std::string> NativeCryptoApiWrapper::derivePrivateKey2(const std::string &password,
+																	 const std::string &salt){
+	ResultWithError<std::string> res;
+	try {
+		res.result = getapi()->derivePrivateKey2(password,
 												salt);
 		}catch(core::Exception& err){
 		res.error = {

--- a/Sources/PrivMXEndpointSwiftNative/include/NativeCryptoApiWrapper.hpp
+++ b/Sources/PrivMXEndpointSwiftNative/include/NativeCryptoApiWrapper.hpp
@@ -36,7 +36,18 @@ public:
 	 * @return WIF Private Key, wrapped in a`ResultWithError` structure for error handling.
 	 *
 	 */
+	[[deprecated("Use generatePrivateKey2(const std::optional<std::string>& randomSeed).")]]
 	ResultWithError<std::string> generatePrivateKey(const OptionalString& basestring);
+	
+	/**
+	 * Generates a new Private Key.
+	 *
+	 * @param baseString  : `const OptionalString&` aka `const std::optional<std:string>&` — Optional base for generating the key
+	 *
+	 * @return WIF Private Key, wrapped in a`ResultWithError` structure for error handling.
+	 *
+	 */
+	ResultWithError<std::string> generatePrivateKey2(const OptionalString& basestring);
 	
 	/**
 	 * Generates a new Private Key from two strings.
@@ -47,7 +58,20 @@ public:
 	 * @return Private WIF key wrapped in a`ResultWithError` structure for error handling.
 	 *
 	 */
+	[[deprecated("Use derivePrivateKey2(const std::string& password, const std::string& salt).")]]
 	ResultWithError<std::string> derivePrivateKey(const std::string& password,
+												 const std::string& salt);
+	
+	/**
+	 * Generates a new Private Key from two strings.
+	 *
+	 * @param password  : `const std::string&`
+	 * @param salt : `const std::string&`
+	 *
+	 * @return Private WIF key wrapped in a`ResultWithError` structure for error handling.
+	 *
+	 */
+	ResultWithError<std::string> derivePrivateKey2(const std::string& password,
 												 const std::string& salt);
 	
 	/**


### PR DESCRIPTION
## Additions
- CryptoApi:
  - `derivePrivateKey2(password:salt:)`
  - `generatePrivateKey2(randomSeed:)`

## Modifications
- CryptoApi:
  - deprecated `derivePrivateKey(password:salt:)`
  - deprecated `generatePrivateKey(randomSeed:)`
