### PR TITLE
Feat: Missing Events

### DIFF
--- a/Sources/PrivMXEndpointSwift/Events/EventHandler.swift
+++ b/Sources/PrivMXEndpointSwift/Events/EventHandler.swift
@@ -637,10 +637,59 @@ public enum EventHandler{
 	/// - Parameter eventHolder: The `EventHolder` instance containing an event to check.
 	/// - Returns: `true` if the `EventHolder` contains a `ThreadDeletedMessageEvent`; otherwise, `false`.
 	/// - Throws: `PrivMXEndpointError.failedQueryingEventHolder` if an error occurs during querying.
+	@available(*, deprecated, renamed: "isThreadMessageDeletedEvent(eventHolder:)", message: "This method has been renamed")
 	public static func isThreadDeletedMessageEvent(
 		eventHolder: privmx.endpoint.core.EventHolder
 	) throws -> Bool {
 		let res = privmx.ThreadEventHandler.isThreadDeletedMessageEvent(eventHolder)
+		guard res.error.value == nil else {
+			throw PrivMXEndpointError.failedQueryingEventHolder(res.error.value!)
+		}
+		guard let result = res.result.value else {
+			var err = privmx.InternalError()
+			err.name = "Value error"
+			err.description = "Unexpectedly received nil result"
+			throw PrivMXEndpointError.failedQueryingEventHolder(err)
+		}
+		return result
+	}
+	
+	/// Checks if the `EventHolder` contains a `ThreadMessageEvent`.
+	///
+	/// This method verifies whether the provided `EventHolder` instance contains an event
+	/// that corresponds to a `privmx.endpoint.thread.ThreadDeletedMessageEvent`.
+	///
+	/// - Parameter eventHolder: The `EventHolder` instance containing an event to check.
+	/// - Returns: `true` if the `EventHolder` contains a `ThreadDeletedMessageEvent`; otherwise, `false`.
+	/// - Throws: `PrivMXEndpointError.failedQueryingEventHolder` if an error occurs during querying.
+	public static func isThreadMessageDeletedEvent(
+		eventHolder: privmx.endpoint.core.EventHolder
+	) throws -> Bool {
+		let res = privmx.ThreadEventHandler.isThreadMessageDeletedEvent(eventHolder)
+		guard res.error.value == nil else {
+			throw PrivMXEndpointError.failedQueryingEventHolder(res.error.value!)
+		}
+		guard let result = res.result.value else {
+			var err = privmx.InternalError()
+			err.name = "Value error"
+			err.description = "Unexpectedly received nil result"
+			throw PrivMXEndpointError.failedQueryingEventHolder(err)
+		}
+		return result
+	}
+	
+	/// Checks if the `EventHolder` contains a `ThreadDeletedMessageEvent`.
+	///
+	/// This method verifies whether the provided `EventHolder` instance contains an event
+	/// that corresponds to a `privmx.endpoint.thread.ThreadDeletedMessageEvent`.
+	///
+	/// - Parameter eventHolder: The `EventHolder` instance containing an event to check.
+	/// - Returns: `true` if the `EventHolder` contains a `ThreadDeletedMessageEvent`; otherwise, `false`.
+	/// - Throws: `PrivMXEndpointError.failedQueryingEventHolder` if an error occurs during querying.
+	public static func isThreadMessageUpdatedEvent(
+		eventHolder: privmx.endpoint.core.EventHolder
+	) throws -> Bool {
+		let res = privmx.ThreadEventHandler.isThreadMessageUpdatedEvent(eventHolder)
 		guard res.error.value == nil else {
 			throw PrivMXEndpointError.failedQueryingEventHolder(res.error.value!)
 		}
@@ -765,10 +814,53 @@ public enum EventHandler{
 	/// - Parameter eventHolder: An `EventHolder` instance containing the `ThreadDeletedMessageEvent`.
 	/// - Returns: The extracted `ThreadDeletedMessageEvent`.
 	/// - Throws: `PrivMXEndpointError.failedExtractingEventFromHolder` if extraction fails.
+	@available(*, deprecated, renamed: "extractThreadMessageDeletedEvent(eventHolder:)")
 	public static func extractThreadDeletedMessageEvent(
 		eventHolder: privmx.endpoint.core.EventHolder
 	) throws -> privmx.endpoint.thread.ThreadMessageDeletedEvent {
 		let res = privmx.ThreadEventHandler.extractThreadDeletedMessageEvent(eventHolder)
+		guard res.error.value == nil else {
+			throw PrivMXEndpointError.failedExtractingEventFromHolder(res.error.value!)
+		}
+		guard let result = res.result.value else {
+			var err = privmx.InternalError()
+			err.name = "Value error"
+			err.description = "Unexpectedly received nil result"
+			throw PrivMXEndpointError.failedExtractingEventFromHolder(err)
+		}
+		return result
+	}
+
+	/// Extracts a `ThreadMessageDeletedEvent` from the provided `EventHolder`.
+	///
+	/// - Parameter eventHolder: An `EventHolder` instance containing the `ThreadMessageDeletedEvent`.
+	/// - Returns: The extracted `ThreadMessageDeletedEvent`.
+	/// - Throws: `PrivMXEndpointError.failedExtractingEventFromHolder` if extraction fails.
+	public static func extractThreadMessageDeletedEvent(
+		eventHolder: privmx.endpoint.core.EventHolder
+	) throws -> privmx.endpoint.thread.ThreadMessageDeletedEvent {
+		let res = privmx.ThreadEventHandler.extractThreadMessageDeletedEvent(eventHolder)
+		guard res.error.value == nil else {
+			throw PrivMXEndpointError.failedExtractingEventFromHolder(res.error.value!)
+		}
+		guard let result = res.result.value else {
+			var err = privmx.InternalError()
+			err.name = "Value error"
+			err.description = "Unexpectedly received nil result"
+			throw PrivMXEndpointError.failedExtractingEventFromHolder(err)
+		}
+		return result
+	}
+	
+	/// Extracts a `ThreadMessageDeletedEvent` from the provided `EventHolder`.
+	///
+	/// - Parameter eventHolder: An `EventHolder` instance containing the `ThreadMessageUpdatedEvent`.
+	/// - Returns: The extracted `ThreadMessageUpdatedEvent`.
+	/// - Throws: `PrivMXEndpointError.failedExtractingEventFromHolder` if extraction fails.
+	public static func extractThreadMessageUpdatedEvent(
+		eventHolder: privmx.endpoint.core.EventHolder
+	) throws -> privmx.endpoint.thread.ThreadMessageUpdatedEvent {
+		let res = privmx.ThreadEventHandler.extractThreadMessageUpdatedEvent(eventHolder)
 		guard res.error.value == nil else {
 			throw PrivMXEndpointError.failedExtractingEventFromHolder(res.error.value!)
 		}

--- a/Sources/PrivMXEndpointSwiftNative/NativeThreadApiWrapper.cpp
+++ b/Sources/PrivMXEndpointSwiftNative/NativeThreadApiWrapper.cpp
@@ -660,10 +660,84 @@ ResultWithError<bool> ThreadEventHandler::isThreadDeletedMessageEvent(const core
 	return res;
 }
 
+ResultWithError<bool> ThreadEventHandler::isThreadMessageDeletedEvent(const core::EventHolder& eventHolder){
+	ResultWithError<bool> res;
+	try{
+		res.result = thread::Events::isThreadDeletedMessageEvent(eventHolder);
+		}catch(core::Exception& err){
+		res.error = {
+			.name = err.getName(),
+			.code = err.getCode(),
+			.description = err.getDescription(),
+			.message = err.what()
+		};
+	}catch (std::exception & err) {
+		res.error ={
+			.name = "std::Exception",
+			.message = err.what()
+		};
+	}catch (...) {
+		res.error ={
+			.name = "Unknown Exception",
+			.message = "Failed to work"
+		};
+	}
+	return res;
+}
+
 ResultWithError<thread::ThreadMessageDeletedEvent> ThreadEventHandler::extractThreadDeletedMessageEvent(const core::EventHolder& eventHolder){
 	ResultWithError<thread::ThreadMessageDeletedEvent> res;
 	try{
 		res.result = thread::Events::extractThreadMessageDeletedEvent(eventHolder);
+		}catch(core::Exception& err){
+		res.error = {
+			.name = err.getName(),
+			.code = err.getCode(),
+			.description = err.getDescription(),
+			.message = err.what()
+		};
+	}catch (std::exception & err) {
+		res.error ={
+			.name = "std::Exception",
+			.message = err.what()
+		};
+	}catch (...) {
+		res.error ={
+			.name = "Unknown Exception",
+			.message = "Failed to work"
+		};
+	}
+	return res;
+}
+
+ResultWithError<thread::ThreadMessageDeletedEvent> ThreadEventHandler::extractThreadMessageDeletedEvent(const core::EventHolder& eventHolder){
+	ResultWithError<thread::ThreadMessageDeletedEvent> res;
+	try{
+		res.result = thread::Events::extractThreadMessageDeletedEvent(eventHolder);
+		}catch(core::Exception& err){
+		res.error = {
+			.name = err.getName(),
+			.code = err.getCode(),
+			.description = err.getDescription(),
+			.message = err.what()
+		};
+	}catch (std::exception & err) {
+		res.error ={
+			.name = "std::Exception",
+			.message = err.what()
+		};
+	}catch (...) {
+		res.error ={
+			.name = "Unknown Exception",
+			.message = "Failed to work"
+		};
+	}
+	return res;
+}
+ResultWithError<thread::ThreadMessageUpdatedEvent> ThreadEventHandler::extractThreadMessageUpdatedEvent(const core::EventHolder& eventHolder){
+	ResultWithError<thread::ThreadMessageUpdatedEvent> res;
+	try{
+		res.result = thread::Events::extractThreadMessageUpdatedEvent(eventHolder);
 		}catch(core::Exception& err){
 		res.error = {
 			.name = err.getName(),

--- a/Sources/PrivMXEndpointSwiftNative/include/NativeThreadApiWrapper.hpp
+++ b/Sources/PrivMXEndpointSwiftNative/include/NativeThreadApiWrapper.hpp
@@ -274,7 +274,28 @@ static ResultWithError<endpoint::thread::ThreadNewMessageEvent> extractThreadNew
  * @return Boolean value wrapped in a `ResultWithError` structure for error handling.
  *
  */
+[[deprecated("Has been renamed, use isThreadDeletedMessageEvent")]]
 static ResultWithError<bool> isThreadDeletedMessageEvent(const endpoint::core::EventHolder& eventHolder);
+
+/**
+ * Checks if an EventHolder contains an `privmx::endpoint::thread::ThreadDeletedMessageEvent`
+ *
+ * @param eventHolder  : `const endpoint::core::EventHolder&`
+ *
+ * @return Boolean value wrapped in a `ResultWithError` structure for error handling.
+ *
+ */
+static ResultWithError<bool> isThreadMessageDeletedEvent(const endpoint::core::EventHolder& eventHolder);
+
+/**
+ * Checks if an EventHolder contains an `privmx::endpoint::thread::ThreadDeletedMessageEvent`
+ *
+ * @param eventHolder  : `const endpoint::core::EventHolder&`
+ *
+ * @return Boolean value wrapped in a `ResultWithError` structure for error handling.
+ *
+ */
+static ResultWithError<bool> isThreadMessageUpdatedEvent(const endpoint::core::EventHolder& eventHolder);
 
 /**
  * Extracts an `privmx::endpoint::thread::ThreadDeletedMessageEvent` from the `privmx::endpoint::core::EventHolder`
@@ -283,7 +304,26 @@ static ResultWithError<bool> isThreadDeletedMessageEvent(const endpoint::core::E
  *
  * @return Extracted `privmx::endpoint::thread::ThreadDeletedMessageEvent` wrapped in a `ResultWithError` structure for error handling.
  */
+[[deprecated("Has been renamed, use extractThreadMessageDeletedEvent")]]
 static ResultWithError<endpoint::thread::ThreadMessageDeletedEvent> extractThreadDeletedMessageEvent(const endpoint::core::EventHolder& eventHolder);
+
+/**
+ * Extracts an `privmx::endpoint::thread::ThreadDeletedMessageEvent` from the `privmx::endpoint::core::EventHolder`
+ *
+ * @param eventHolder  : `const endpoint::core::EventHolder&`
+ *
+ * @return Extracted `privmx::endpoint::thread::ThreadDeletedMessageEvent` wrapped in a `ResultWithError` structure for error handling.
+ */
+static ResultWithError<endpoint::thread::ThreadMessageDeletedEvent> extractThreadMessageDeletedEvent(const endpoint::core::EventHolder& eventHolder);
+
+/**
+ * Extracts an `privmx::endpoint::thread::ThreadDeletedMessageEvent` from the `privmx::endpoint::core::EventHolder`
+ *
+ * @param eventHolder  : `const endpoint::core::EventHolder&`
+ *
+ * @return Extracted `privmx::endpoint::thread::ThreadDeletedMessageEvent` wrapped in a `ResultWithError` structure for error handling.
+ */
+static ResultWithError<endpoint::thread::ThreadMessageUpdatedEvent> extractThreadMessageUpdatedEvent(const endpoint::core::EventHolder& eventHolder);
 
 /**
  * Checks if an EventHolder contains an `privmx::endpoint::thread::ThreadStatsEvent`


### PR DESCRIPTION
## Additions:
- Methods for handling `ThreadMessageUpdatedEvent`s
- New methods for handling `ThreadMessageDeletedEvent`s

## Modifications:
- Deprecated `isThreadDeletedMessageEvent(eventHolder:)`
- Deprecated `extractThreadDeletedMessageEvent(eventHolder:)`
