### PR TITLE
Feat: getContextUsers

### DIFF
--- a/Sources/PrivMXEndpointSwift/Core/Connection.swift
+++ b/Sources/PrivMXEndpointSwift/Core/Connection.swift
@@ -227,7 +227,13 @@ public class Connection{
 		return result
 	}
 	
-	
+	/// Retrieves a list of Users from a particular Context.
+	///
+	/// - parameter contextId: Id of the Context.
+	///
+	/// - throws: When the operation fails.
+	///
+	/// - returns: a list of UserInfo objects.
 	public func getContextUsers(
 		contextId: std.string
 	) throws -> privmx.UserInfoVector {

--- a/Sources/PrivMXEndpointSwift/Core/Connection.swift
+++ b/Sources/PrivMXEndpointSwift/Core/Connection.swift
@@ -228,4 +228,19 @@ public class Connection{
 	}
 	
 	
+	public func getContextUsers(
+		contextId: std.string
+	) throws -> privmx.UserInfoVector {
+		let res = api.getContextUsers(contextId)
+		guard res.error.value == nil else {
+			throw PrivMXEndpointError.failedGettingContextUsers(res.error.value!)
+		}
+		guard let result = res.result.value else {
+			var err = privmx.InternalError()
+			err.name = "Value error"
+			err.description = "Unexpectedly recived nil result"
+			throw PrivMXEndpointError.failedGettingContextUsers(err)
+		}
+		return result
+	}
 }

--- a/Sources/PrivMXEndpointSwift/Errors/PrivMXEndpointError.swift
+++ b/Sources/PrivMXEndpointSwift/Errors/PrivMXEndpointError.swift
@@ -45,6 +45,8 @@ public enum PrivMXEndpointError : Error{
 	case failedDisconnecting(privmx.InternalError)
 	/// Failed to list Contexts
 	case failedListingContexts(privmx.InternalError)
+	/// Falied to get a list of Users from a Context
+	case failedGettingContextUsers(privmx.InternalError)
 	
 	/// Failed to instantiate `ThreadApi`
 	case failedInstantiatingThreadApi(privmx.InternalError)
@@ -179,6 +181,7 @@ public enum PrivMXEndpointError : Error{
 					.failedConnecting(let err),
 					.failedDisconnecting(let err),
 					.failedListingContexts(let err),
+					.failedGettingContextUsers(let err),
 					.failedCreatingThread(let err),
 					.failedGettingThread(let err),
 					.failedListingThreads(let err),
@@ -251,6 +254,7 @@ public enum PrivMXEndpointError : Error{
 					.failedConnecting(let err),
 					.failedDisconnecting(let err),
 					.failedListingContexts(let err),
+					.failedGettingContextUsers(let err),
 					.failedCreatingThread(let err),
 					.failedGettingThread(let err),
 					.failedListingThreads(let err),
@@ -323,6 +327,7 @@ public enum PrivMXEndpointError : Error{
 					.failedConnecting(let err),
 					.failedDisconnecting(let err),
 					.failedListingContexts(let err),
+					.failedGettingContextUsers(let err),
 					.failedCreatingThread(let err),
 					.failedGettingThread(let err),
 					.failedListingThreads(let err),
@@ -394,6 +399,7 @@ public enum PrivMXEndpointError : Error{
 					.failedConnecting(let err),
 					.failedDisconnecting(let err),
 					.failedListingContexts(let err),
+					.failedGettingContextUsers(let err),
 					.failedCreatingThread(let err),
 					.failedGettingThread(let err),
 					.failedListingThreads(let err),

--- a/Sources/PrivMXEndpointSwiftNative/NativeConnectionWrapper.cpp
+++ b/Sources/PrivMXEndpointSwiftNative/NativeConnectionWrapper.cpp
@@ -172,6 +172,31 @@ ResultWithError<ContextList> NativeConnectionWrapper::listContexts(const core::P
 	return res;
 }
 
+ResultWithError<UserInfoVector> NativeConnectionWrapper::getContextUsers(const std::string &contextId){
+	ResultWithError<UserInfoVector> res;
+	try{
+		res.result = getApi()->getContextUsers(contextId);
+	}catch(core::Exception& err){
+		res.error = {
+			.name = err.getName(),
+			.code = err.getCode(),
+			.description = err.getDescription(),
+			.message = err.what()
+		};
+	}catch (std::exception & err) {
+		res.error ={
+			.name = "std::Exception",
+			.message = err.what()
+		};
+	}catch (...) {
+		res.error ={
+			.name = "Unknown Exception",
+			.message = "Failed to work"
+		};
+	}
+	return res;
+}
+
 ResultWithError<int64_t> NativeConnectionWrapper::getConnectionId(){
 	ResultWithError<int64_t> res;
 	try {

--- a/Sources/PrivMXEndpointSwiftNative/include/NativeConnectionWrapper.hpp
+++ b/Sources/PrivMXEndpointSwiftNative/include/NativeConnectionWrapper.hpp
@@ -111,6 +111,8 @@ public:
 	 * @return struct containing a list of Contexts wrapped in a `ResultWithError` object for error handling.
 	 */
 	ResultWithError<ContextList> listContexts(const endpoint::core::PagingQuery& query);
+	
+	ResultWithError<UserInfoVector> getContextUsers(const std::string& contextId);
 private:
 	
 	std::shared_ptr<endpoint::core::Connection> getApi();

--- a/Sources/PrivMXEndpointSwiftNative/include/PrivMXUtils.hpp
+++ b/Sources/PrivMXEndpointSwiftNative/include/PrivMXUtils.hpp
@@ -53,6 +53,7 @@ using InboxFileHandleVector = std::vector<InboxFileHandle>;
 using StringVector = std::vector<std::string>;
 using OptionalString = std::optional<std::string>;
 using UserWithPubKeyVector = std::vector<endpoint::core::UserWithPubKey>;
+using UserInfoVector = std::vector<endpoint::core::UserInfo>;
 
 using OptionalInboxFilesConfig = std::optional<endpoint::inbox::FilesConfig>;
 


### PR DESCRIPTION
## Additions
- `UserInfoVector` alias for UserInfo specialisation of vector template
- `getContextUsers(contextId:)` method in `Connection`
- new error case for the method