### PR TITLE
Feat: getChannel method

### DIFF
--- a/Sources/PrivMXEndpointSwiftNative/include/PrivMXUtils.hpp
+++ b/Sources/PrivMXEndpointSwiftNative/include/PrivMXUtils.hpp
@@ -163,6 +163,10 @@ static std::string stringFromBuffer(const endpoint::core::Buffer& buf){
 	return std::string(buf.stdString());
 }
 
+static std::string getChannelFrom(const endpoint::event::ContextCustomEvent& event){
+	return event.channel;
+}
+
 }
 
 #endif /* _PRIVMX_ENDPOINT_SWIFT_NATIVE_PRIVMXUTILS */


### PR DESCRIPTION
- added a workaround for https://github.com/swiftlang/swift/issues/76650 when working with `ContextCustomEvent`