### PR TITLE
Feat: New Utils and Constants

### DIFF
--- a/Sources/PrivMXEndpointSwift/Crypto/BIP39.swift
+++ b/Sources/PrivMXEndpointSwift/Crypto/BIP39.swift
@@ -1,0 +1,43 @@
+//
+// PrivMX Endpoint Swift
+// Copyright © 2024 Simplito sp. z o.o.
+//
+// This file is part of PrivMX Platform (https://privmx.dev).
+// This software is Licensed under the MIT License.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import PrivMXEndpointSwiftNative
+
+public struct BIP39{
+	
+	internal var wrapped: privmx.endpoint.crypto.BIP39_t
+	
+	public var ext_key:ExtKey
+	
+	public var mnemonic:std.string{
+		get{
+			wrapped.mnemonic
+		}
+		set(val){
+			wrapped.mnemonic = val
+		}
+	}
+	
+	public var entropy: privmx.endpoint.core.Buffer{
+		get{
+			wrapped.entropy
+		}
+		set(val){
+			wrapped.entropy = val
+		}
+	}
+	
+	init(wrapping: privmx.endpoint.crypto.BIP39_t) {
+		self.wrapped = wrapping
+		self.ext_key = ExtKey(wrapped:wrapping.ext_key)
+	}
+	
+}

--- a/Sources/PrivMXEndpointSwift/Crypto/BIP39.swift
+++ b/Sources/PrivMXEndpointSwift/Crypto/BIP39.swift
@@ -11,12 +11,17 @@
 
 import PrivMXEndpointSwiftNative
 
+/// Struct containing ECC generated key using BIP-39.
+///
+/// This struct is used for safe handling of potentially throwing methods of ExtKey
 public struct BIP39{
 	
 	internal var wrapped: privmx.endpoint.crypto.BIP39_t
 	
+	/// Ecc Key.
 	public var ext_key:ExtKey
 	
+	/// BIP-39 mnemonic.
 	public var mnemonic:std.string{
 		get{
 			wrapped.mnemonic
@@ -26,6 +31,7 @@ public struct BIP39{
 		}
 	}
 	
+	/// BIP-39 entropy.
 	public var entropy: privmx.endpoint.core.Buffer{
 		get{
 			wrapped.entropy

--- a/Sources/PrivMXEndpointSwift/Crypto/ExtKey.swift
+++ b/Sources/PrivMXEndpointSwift/Crypto/ExtKey.swift
@@ -1,0 +1,246 @@
+//
+// PrivMX Endpoint Swift
+// Copyright © 2024 Simplito sp. z o.o.
+//
+// This file is part of PrivMX Platform (https://privmx.dev).
+// This software is Licensed under the MIT License.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+import PrivMXEndpointSwiftNative
+
+public class ExtKey{
+	internal var wrapped: privmx.endpoint.crypto.ExtKey
+	
+	init(
+		wrapped: privmx.endpoint.crypto.ExtKey
+	) {
+		self.wrapped = wrapped
+	}
+	
+	public func fromSeed(
+		seed: privmx.endpoint.core.Buffer
+	) throws -> ExtKey {
+		let res = privmx.endpoint.wrapper._call_ExtKey_fromSeed(seed)
+		guard res.error.value == nil else {
+			throw PrivMXEndpointError.failedInstantiatingExtKey(res.error.value!)
+		}
+		guard let result = res.result.value else {
+			var err = privmx.InternalError()
+			err.name = "Value error"
+			err.description = "Unexpectedly recived nil result"
+			throw PrivMXEndpointError.failedInstantiatingExtKey(err)
+		}
+		return ExtKey(wrapped:result)
+	}
+	
+	
+	public func fromBase58(
+		base58: std.string
+	) throws -> ExtKey {
+		let res = privmx.endpoint.wrapper._call_ExtKey_fromBase58(base58)
+		guard res.error.value == nil else {
+			throw PrivMXEndpointError.failedInstantiatingExtKey(res.error.value!)
+		}
+		guard let result = res.result.value else {
+			var err = privmx.InternalError()
+			err.name = "Value error"
+			err.description = "Unexpectedly recived nil result"
+			throw PrivMXEndpointError.failedInstantiatingExtKey(err)
+		}
+		return ExtKey(wrapped:result)
+	}
+	
+	public func generateRandom(
+	) throws -> ExtKey {
+		let res = privmx.endpoint.wrapper._call_ExtKey_generateRandom()
+		guard res.error.value == nil else {
+			throw PrivMXEndpointError.failedInstantiatingExtKey(res.error.value!)
+		}
+		guard let result = res.result.value else {
+			var err = privmx.InternalError()
+			err.name = "Value error"
+			err.description = "Unexpectedly recived nil result"
+			throw PrivMXEndpointError.failedInstantiatingExtKey(err)
+		}
+		return ExtKey(wrapped:result)
+	}
+	
+	
+	public func derive(
+		index:UInt32
+	) throws -> ExtKey {
+		let res = privmx.endpoint.wrapper._call_ExtKey_derive(wrapped, index)
+		guard res.error.value == nil else {
+			throw PrivMXEndpointError.failedDerivingExtKey(res.error.value!)
+		}
+		guard let result = res.result.value else {
+			var err = privmx.InternalError()
+			err.name = "Value error"
+			err.description = "Unexpectedly recived nil result"
+			throw PrivMXEndpointError.failedDerivingExtKey(err)
+		}
+		return ExtKey(wrapped:result)
+	}
+
+	public func deriveHardened(
+		index:UInt32
+	) throws -> ExtKey {
+		let res = privmx.endpoint.wrapper._call_ExtKey_deriveHardened(wrapped, index)
+		guard res.error.value == nil else {
+			throw PrivMXEndpointError.failedDerivingExtKey(res.error.value!)
+		}
+		guard let result = res.result.value else {
+			var err = privmx.InternalError()
+			err.name = "Value error"
+			err.description = "Unexpectedly recived nil result"
+			throw PrivMXEndpointError.failedDerivingExtKey(err)
+		}
+		return ExtKey(wrapped:result)
+	}
+	
+	
+	public func getPrivatePartAsBase58(
+	) throws -> std.string {
+		let res = privmx.endpoint.wrapper._call_ExtKey_getPrivatePartAsBase58(wrapped)
+		guard res.error.value == nil else {
+			throw PrivMXEndpointError.failedGettingPrivatePartAsBase58(res.error.value!)
+		}
+		guard let result = res.result.value else {
+			var err = privmx.InternalError()
+			err.name = "Value error"
+			err.description = "Unexpectedly recived nil result"
+			throw PrivMXEndpointError.failedGettingPrivatePartAsBase58(err)
+		}
+		return result
+	}
+	
+	public func getPublicPartAsBase58(
+	) throws -> std.string {
+		let res = privmx.endpoint.wrapper._call_ExtKey_getPublicPartAsBase58(wrapped)
+		guard res.error.value == nil else {
+			throw PrivMXEndpointError.failedGettingPublicPartAsBase58(res.error.value!)
+		}
+		guard let result = res.result.value else {
+			var err = privmx.InternalError()
+			err.name = "Value error"
+			err.description = "Unexpectedly recived nil result"
+			throw PrivMXEndpointError.failedGettingPublicPartAsBase58(err)
+		}
+		return result
+	}
+	
+	
+	public func getPrivateKey(
+	) throws -> std.string {
+		let res = privmx.endpoint.wrapper._call_ExtKey_getPrivateKey(wrapped)
+		guard res.error.value == nil else {
+			throw PrivMXEndpointError.failedGettingPrivateKey(res.error.value!)
+		}
+		guard let result = res.result.value else {
+			var err = privmx.InternalError()
+			err.name = "Value error"
+			err.description = "Unexpectedly recived nil result"
+			throw PrivMXEndpointError.failedGettingPrivateKey(err)
+		}
+		return result
+	}
+
+	public func getPublicKey(
+	) throws -> std.string {
+		let res = privmx.endpoint.wrapper._call_ExtKey_getPublicKey(wrapped)
+		guard res.error.value == nil else {
+			throw PrivMXEndpointError.failedGettingPublicKey(res.error.value!)
+		}
+		guard let result = res.result.value else {
+			var err = privmx.InternalError()
+			err.name = "Value error"
+			err.description = "Unexpectedly recived nil result"
+			throw PrivMXEndpointError.failedGettingPublicKey(err)
+		}
+		return result
+	}
+	
+	public func getPublicKeyAsBase58Address(
+	) throws -> std.string {
+		let res = privmx.endpoint.wrapper._call_ExtKey_getPublicKeyAsBase58Address(wrapped)
+		guard res.error.value == nil else {
+			throw PrivMXEndpointError.failedGettingPublicKeyAsBase58Address(res.error.value!)
+		}
+		guard let result = res.result.value else {
+			var err = privmx.InternalError()
+			err.name = "Value error"
+			err.description = "Unexpectedly recived nil result"
+			throw PrivMXEndpointError.failedGettingPublicKeyAsBase58Address(err)
+		}
+		return result
+	}
+	
+	
+	public func getPrivateEncKey(
+	) throws -> privmx.endpoint.core.Buffer {
+		let res = privmx.endpoint.wrapper._call_ExtKey_getPrivateEncKey(wrapped)
+		guard res.error.value == nil else {
+			throw PrivMXEndpointError.failedGettingPrivateEncKey(res.error.value!)
+		}
+		guard let result = res.result.value else {
+			var err = privmx.InternalError()
+			err.name = "Value error"
+			err.description = "Unexpectedly recived nil result"
+			throw PrivMXEndpointError.failedGettingPrivateEncKey(err)
+		}
+		return result
+	}
+	
+	public func getChainCode(
+	) throws -> privmx.endpoint.core.Buffer {
+		let res = privmx.endpoint.wrapper._call_ExtKey_getChainCode(wrapped)
+		guard res.error.value == nil else {
+			throw PrivMXEndpointError.failedGettingChainCode(res.error.value!)
+		}
+		guard let result = res.result.value else {
+			var err = privmx.InternalError()
+			err.name = "Value error"
+			err.description = "Unexpectedly recived nil result"
+			throw PrivMXEndpointError.failedGettingChainCode(err)
+		}
+		return result
+	}
+	
+	
+	public func verifyCompactSignatureWithHash(
+		message: privmx.endpoint.core.Buffer,
+		signature: privmx.endpoint.core.Buffer
+	) throws -> Bool {
+		let res = privmx.endpoint.wrapper._call_ExtKey_verifyCompactSignatureWithHash(wrapped,
+																					  message,
+																					  signature)
+		guard res.error.value == nil else {
+			throw PrivMXEndpointError.failedVerifyingCompactSignature(res.error.value!)
+		}
+		guard let result = res.result.value else {
+			var err = privmx.InternalError()
+			err.name = "Value error"
+			err.description = "Unexpectedly recived nil result"
+			throw PrivMXEndpointError.failedVerifyingCompactSignature(err)
+		}
+		return result
+	}
+	
+	public func isPrivate(
+	) throws -> Bool {
+		let res = privmx.endpoint.wrapper._call_ExtKey_isPrivate(wrapped)
+		guard res.error.value == nil else {
+			throw PrivMXEndpointError.failedCheckingIfExtKeyIsPrivate(res.error.value!)
+		}
+		guard let result = res.result.value else {
+			var err = privmx.InternalError()
+			err.name = "Value error"
+			err.description = "Unexpectedly recived nil result"
+			throw PrivMXEndpointError.failedCheckingIfExtKeyIsPrivate(err)
+		}
+		return result
+	}
+	
+}

--- a/Sources/PrivMXEndpointSwift/Crypto/ExtKey.swift
+++ b/Sources/PrivMXEndpointSwift/Crypto/ExtKey.swift
@@ -10,6 +10,9 @@
 //
 import PrivMXEndpointSwiftNative
 
+/// `ExtKey` is a class representing Extended keys and operations on it.
+///
+///  This class allows for safely using the underaying `privmx.endpoint.crypto.ExtKey`
 public class ExtKey{
 	internal var wrapped: privmx.endpoint.crypto.ExtKey
 	
@@ -18,7 +21,10 @@ public class ExtKey{
 	) {
 		self.wrapped = wrapped
 	}
-	
+
+	/// Creates ExtKey from given seed.
+	/// - Parameter seed: the seed used to generate Key
+	/// - Returns: `ExtKey` object
 	public func fromSeed(
 		seed: privmx.endpoint.core.Buffer
 	) throws -> ExtKey {
@@ -35,7 +41,9 @@ public class ExtKey{
 		return ExtKey(wrapped:result)
 	}
 	
-	
+	/// Decodes ExtKey from Base58 format.
+	/// - Parameter base58:the ExtKey in Base58
+	/// - Returns: `ExtKey` object
 	public func fromBase58(
 		base58: std.string
 	) throws -> ExtKey {
@@ -52,6 +60,8 @@ public class ExtKey{
 		return ExtKey(wrapped:result)
 	}
 	
+	/// Generates a new ExtKey.
+	/// - Returns: `ExtKey` object
 	public func generateRandom(
 	) throws -> ExtKey {
 		let res = privmx.endpoint.wrapper._call_ExtKey_generateRandom()
@@ -67,7 +77,9 @@ public class ExtKey{
 		return ExtKey(wrapped:result)
 	}
 	
-	
+	/// Generates child ExtKey from a current ExtKey using BIP32.
+	/// - Parameter index: number from 0 to 2^31-1
+	/// - Returns: `ExtKey` object
 	public func derive(
 		index:UInt32
 	) throws -> ExtKey {
@@ -84,6 +96,9 @@ public class ExtKey{
 		return ExtKey(wrapped:result)
 	}
 
+	/// Generates hardened child ExtKey from a current ExtKey using BIP32.
+	/// - Parameter index: number from 0 to 2^31-1
+	/// - Returns: `ExtKey` object
 	public func deriveHardened(
 		index:UInt32
 	) throws -> ExtKey {
@@ -100,7 +115,8 @@ public class ExtKey{
 		return ExtKey(wrapped:result)
 	}
 	
-	
+	/// Converts ExtKey to Base58 string.
+	/// - Returns: `ExtKey` in Base58 format
 	public func getPrivatePartAsBase58(
 	) throws -> std.string {
 		let res = privmx.endpoint.wrapper._call_ExtKey_getPrivatePartAsBase58(wrapped)
@@ -116,6 +132,8 @@ public class ExtKey{
 		return result
 	}
 	
+	/// Converts the public part of ExtKey to Base58 string.
+	/// - Returns: `ExtKey` in Base58 format
 	public func getPublicPartAsBase58(
 	) throws -> std.string {
 		let res = privmx.endpoint.wrapper._call_ExtKey_getPublicPartAsBase58(wrapped)
@@ -131,7 +149,8 @@ public class ExtKey{
 		return result
 	}
 	
-	
+	/// Extracts ECC PrivateKey.
+	/// - Returns: ECC key in WIF format
 	public func getPrivateKey(
 	) throws -> std.string {
 		let res = privmx.endpoint.wrapper._call_ExtKey_getPrivateKey(wrapped)
@@ -147,6 +166,8 @@ public class ExtKey{
 		return result
 	}
 
+	/// Extracts ECC PublicKey.
+	/// - Returns: ECC key in BASE58DER format
 	public func getPublicKey(
 	) throws -> std.string {
 		let res = privmx.endpoint.wrapper._call_ExtKey_getPublicKey(wrapped)
@@ -162,6 +183,8 @@ public class ExtKey{
 		return result
 	}
 	
+	/// Extracts ECC PublicKey Address.
+	/// - Returns: ECC Address in BASE58 format
 	public func getPublicKeyAsBase58Address(
 	) throws -> std.string {
 		let res = privmx.endpoint.wrapper._call_ExtKey_getPublicKeyAsBase58Address(wrapped)
@@ -177,7 +200,8 @@ public class ExtKey{
 		return result
 	}
 	
-	
+	/// Extracts raw ECC PrivateKey.
+	/// - Returns: ECC PrivateKey
 	public func getPrivateEncKey(
 	) throws -> privmx.endpoint.core.Buffer {
 		let res = privmx.endpoint.wrapper._call_ExtKey_getPrivateEncKey(wrapped)
@@ -193,6 +217,8 @@ public class ExtKey{
 		return result
 	}
 	
+	/// Gets the chain code of Extended Key.
+	/// - Returns: Raw chain code
 	public func getChainCode(
 	) throws -> privmx.endpoint.core.Buffer {
 		let res = privmx.endpoint.wrapper._call_ExtKey_getChainCode(wrapped)
@@ -208,7 +234,10 @@ public class ExtKey{
 		return result
 	}
 	
-	
+	///  Validates a signature of a message.
+	/// - Parameter  message: data used on validation
+	/// - Parameter  signature: signature of data to verify
+	/// - Returns:  message validation result
 	public func verifyCompactSignatureWithHash(
 		message: privmx.endpoint.core.Buffer,
 		signature: privmx.endpoint.core.Buffer
@@ -228,6 +257,8 @@ public class ExtKey{
 		return result
 	}
 	
+	/// Checks if ExtKey is Private.
+	/// - Returns: returns true if ExtKey is private
 	public func isPrivate(
 	) throws -> Bool {
 		let res = privmx.endpoint.wrapper._call_ExtKey_isPrivate(wrapped)

--- a/Sources/PrivMXEndpointSwift/Errors/PrivMXEndpointError.swift
+++ b/Sources/PrivMXEndpointSwift/Errors/PrivMXEndpointError.swift
@@ -175,6 +175,18 @@ public enum PrivMXEndpointError : Error{
 	
 	case FailedSettingUserVerifier(privmx.InternalError)
 	
+	case failedInstantiatingExtKey(privmx.InternalError)
+	case failedDerivingExtKey(privmx.InternalError)
+	case failedGettingPrivatePartAsBase58(privmx.InternalError)
+	case failedGettingPublicPartAsBase58(privmx.InternalError)
+	case failedGettingPrivateKey(privmx.InternalError)
+	case failedGettingPublicKey(privmx.InternalError)
+	case failedGettingPublicKeyAsBase58Address(privmx.InternalError)
+	case failedGettingPrivateEncKey(privmx.InternalError)
+	case failedGettingChainCode(privmx.InternalError)
+	case failedVerifyingCompactSignature(privmx.InternalError)
+	case failedCheckingIfExtKeyIsPrivate(privmx.InternalError)
+	
 	/// Gets the Message of the error
 	///
 	///  - Returns: Message of the error
@@ -248,6 +260,17 @@ public enum PrivMXEndpointError : Error{
 					.FailedEmittingCustomEvent(let err),
 					.FailedSubscribingForCustomEvents(let err),
 					.FailedUnsubscribingFromCustomEvents(let err),
+					.failedInstantiatingExtKey(let err),
+					.failedDerivingExtKey(let err),
+					.failedGettingPublicPartAsBase58(let err),
+					.failedGettingPrivatePartAsBase58(let err),
+					.failedGettingPrivateKey(let err),
+					.failedGettingPublicKey(let err),
+					.failedGettingPublicKeyAsBase58Address(let err),
+					.failedGettingPrivateEncKey(let err),
+					.failedGettingChainCode(let err),
+					.failedVerifyingCompactSignature(let err),
+					.failedCheckingIfExtKeyIsPrivate(let err),
 					.FailedSettingUserVerifier(let err):
 				return String(err.message)
 		}
@@ -326,6 +349,17 @@ public enum PrivMXEndpointError : Error{
 					.FailedEmittingCustomEvent(let err),
 					.FailedSubscribingForCustomEvents(let err),
 					.FailedUnsubscribingFromCustomEvents(let err),
+					.failedInstantiatingExtKey(let err),
+					.failedDerivingExtKey(let err),
+					.failedGettingPublicPartAsBase58(let err),
+					.failedGettingPrivatePartAsBase58(let err),
+					.failedGettingPrivateKey(let err),
+					.failedGettingPublicKey(let err),
+					.failedGettingPublicKeyAsBase58Address(let err),
+					.failedGettingPrivateEncKey(let err),
+					.failedGettingChainCode(let err),
+					.failedVerifyingCompactSignature(let err),
+					.failedCheckingIfExtKeyIsPrivate(let err),
 					.FailedSettingUserVerifier(let err):
 				return err.code.value
 		}
@@ -404,6 +438,17 @@ public enum PrivMXEndpointError : Error{
 					.FailedEmittingCustomEvent(let err),
 					.FailedSubscribingForCustomEvents(let err),
 					.FailedUnsubscribingFromCustomEvents(let err),
+					.failedInstantiatingExtKey(let err),
+					.failedDerivingExtKey(let err),
+					.failedGettingPublicPartAsBase58(let err),
+					.failedGettingPrivatePartAsBase58(let err),
+					.failedGettingPrivateKey(let err),
+					.failedGettingPublicKey(let err),
+					.failedGettingPublicKeyAsBase58Address(let err),
+					.failedGettingPrivateEncKey(let err),
+					.failedGettingChainCode(let err),
+					.failedVerifyingCompactSignature(let err),
+					.failedCheckingIfExtKeyIsPrivate(let err),
 					.FailedSettingUserVerifier(let err):
 				return String(err.name)
 		}
@@ -481,6 +526,17 @@ public enum PrivMXEndpointError : Error{
 					.FailedEmittingCustomEvent(let err),
 					.FailedSubscribingForCustomEvents(let err),
 					.FailedUnsubscribingFromCustomEvents(let err),
+					.failedInstantiatingExtKey(let err),
+					.failedDerivingExtKey(let err),
+					.failedGettingPublicPartAsBase58(let err),
+					.failedGettingPrivatePartAsBase58(let err),
+					.failedGettingPrivateKey(let err),
+					.failedGettingPublicKey(let err),
+					.failedGettingPublicKeyAsBase58Address(let err),
+					.failedGettingPrivateEncKey(let err),
+					.failedGettingChainCode(let err),
+					.failedVerifyingCompactSignature(let err),
+					.failedCheckingIfExtKeyIsPrivate(let err),
 					.FailedSettingUserVerifier(let err):
 				return String(err.description)
 		}

--- a/Sources/PrivMXEndpointSwiftNative/NativeExtKeyWrapper.cpp
+++ b/Sources/PrivMXEndpointSwiftNative/NativeExtKeyWrapper.cpp
@@ -1,0 +1,12 @@
+//
+// PrivMX Endpoint Swift
+// Copyright © 2024 Simplito sp. z o.o.
+//
+// This file is part of PrivMX Platform (https://privmx.dev).
+// This software is Licensed under the MIT License.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "NativeExtKeyWrapper.hpp"

--- a/Sources/PrivMXEndpointSwiftNative/include/NativeExtKeyWrapper.hpp
+++ b/Sources/PrivMXEndpointSwiftNative/include/NativeExtKeyWrapper.hpp
@@ -1,0 +1,380 @@
+//
+// PrivMX Endpoint Swift
+// Copyright © 2024 Simplito sp. z o.o.
+//
+// This file is part of PrivMX Platform (https://privmx.dev).
+// This software is Licensed under the MIT License.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef NATIVE_EXTKEY_WRAPPER_HPP
+#define NATIVE_EXTKEY_WRAPPER_HPP
+#include "PrivMXUtils.hpp"
+
+namespace privmx{
+namespace endpoint{
+namespace wrapper{
+
+static ResultWithError<endpoint::crypto::ExtKey> _call_ExtKey_fromSeed(const core::Buffer& seed) noexcept{
+	ResultWithError<endpoint::crypto::ExtKey> res;
+	try{
+		res.result = endpoint::crypto::ExtKey::fromSeed(seed);
+	}catch(core::Exception& err){
+		res.error = {
+			.name = err.getName(),
+			.code = err.getCode(),
+			.description = err.getDescription(),
+			.message = err.what()
+		};
+	}catch (std::exception & err) {
+		res.error ={
+			.name = "std::Exception",
+			.message = err.what()
+		};
+	}catch (...) {
+		res.error ={
+			.name = "Unknown Exception",
+			.message = "Failed to work"
+		};
+	}
+	return res;
+}
+
+static ResultWithError<endpoint::crypto::ExtKey> _call_ExtKey_fromBase58(const std::string& base58) noexcept{
+	ResultWithError<endpoint::crypto::ExtKey> res;
+	try{
+		res.result = endpoint::crypto::ExtKey::fromBase58(base58);
+	}catch(core::Exception& err){
+		res.error = {
+			.name = err.getName(),
+			.code = err.getCode(),
+			.description = err.getDescription(),
+			.message = err.what()
+		};
+	}catch (std::exception & err) {
+		res.error ={
+			.name = "std::Exception",
+			.message = err.what()
+		};
+	}catch (...) {
+		res.error ={
+			.name = "Unknown Exception",
+			.message = "Failed to work"
+		};
+	}
+	return res;
+}
+
+static ResultWithError<endpoint::crypto::ExtKey> _call_ExtKey_generateRandom() noexcept{
+	ResultWithError<endpoint::crypto::ExtKey> res;
+	try{
+		res.result = endpoint::crypto::ExtKey::generateRandom();
+	}catch(core::Exception& err){
+		res.error = {
+			.name = err.getName(),
+			.code = err.getCode(),
+			.description = err.getDescription(),
+			.message = err.what()
+		};
+	}catch (std::exception & err) {
+		res.error ={
+			.name = "std::Exception",
+			.message = err.what()
+		};
+	}catch (...) {
+		res.error ={
+			.name = "Unknown Exception",
+			.message = "Failed to work"
+		};
+	}
+	return res;
+}
+
+static ResultWithError<endpoint::crypto::ExtKey> _call_ExtKey_derive(const endpoint::crypto::ExtKey& extKey,
+																			  uint32_t index) noexcept {
+	ResultWithError<endpoint::crypto::ExtKey> res;
+	try{
+		res.result = extKey.derive(index);
+	}catch(core::Exception& err){
+		res.error = {
+			.name = err.getName(),
+			.code = err.getCode(),
+			.description = err.getDescription(),
+			.message = err.what()
+		};
+	}catch (std::exception & err) {
+		res.error ={
+			.name = "std::Exception",
+			.message = err.what()
+		};
+	}catch (...) {
+		res.error ={
+			.name = "Unknown Exception",
+			.message = "Failed to work"
+		};
+	}
+	return res;
+}
+
+static ResultWithError<endpoint::crypto::ExtKey> _call_ExtKey_deriveHardened(const endpoint::crypto::ExtKey& extKey,
+																					  uint32_t index) noexcept {
+	ResultWithError<endpoint::crypto::ExtKey> res;
+	try{
+		res.result = extKey.deriveHardened(index);
+	}catch(core::Exception& err){
+		res.error = {
+			.name = err.getName(),
+			.code = err.getCode(),
+			.description = err.getDescription(),
+			.message = err.what()
+		};
+	}catch (std::exception & err) {
+		res.error ={
+			.name = "std::Exception",
+			.message = err.what()
+		};
+	}catch (...) {
+		res.error ={
+			.name = "Unknown Exception",
+			.message = "Failed to work"
+		};
+	}
+	return res;
+}
+
+static ResultWithError<std::string> _call_ExtKey_getPrivatePartAsBase58(const endpoint::crypto::ExtKey& extKey) noexcept {
+	ResultWithError<std::string> res;
+	try{
+		res.result = extKey.getPrivatePartAsBase58();
+	}catch(core::Exception& err){
+		res.error = {
+			.name = err.getName(),
+			.code = err.getCode(),
+			.description = err.getDescription(),
+			.message = err.what()
+		};
+	}catch (std::exception & err) {
+		res.error ={
+			.name = "std::Exception",
+			.message = err.what()
+		};
+	}catch (...) {
+		res.error ={
+			.name = "Unknown Exception",
+			.message = "Failed to work"
+		};
+	}
+	return res;
+}
+
+static ResultWithError<std::string> _call_ExtKey_getPublicPartAsBase58(const endpoint::crypto::ExtKey& extKey) noexcept {
+	ResultWithError<std::string> res;
+	try{
+		res.result = extKey.getPublicPartAsBase58();
+	}catch(core::Exception& err){
+		res.error = {
+			.name = err.getName(),
+			.code = err.getCode(),
+			.description = err.getDescription(),
+			.message = err.what()
+		};
+	}catch (std::exception & err) {
+		res.error ={
+			.name = "std::Exception",
+			.message = err.what()
+		};
+	}catch (...) {
+		res.error ={
+			.name = "Unknown Exception",
+			.message = "Failed to work"
+		};
+	}
+	return res;
+}
+
+static ResultWithError<std::string> _call_ExtKey_getPrivateKey(const endpoint::crypto::ExtKey& extKey) noexcept {
+	ResultWithError<std::string> res;
+	try{
+		res.result = extKey.getPrivateKey();
+	}catch(core::Exception& err){
+		res.error = {
+			.name = err.getName(),
+			.code = err.getCode(),
+			.description = err.getDescription(),
+			.message = err.what()
+		};
+	}catch (std::exception & err) {
+		res.error ={
+			.name = "std::Exception",
+			.message = err.what()
+		};
+	}catch (...) {
+		res.error ={
+			.name = "Unknown Exception",
+			.message = "Failed to work"
+		};
+	}
+	return res;
+}
+
+static ResultWithError<std::string> _call_ExtKey_getPublicKey(const endpoint::crypto::ExtKey& extKey) noexcept {
+	ResultWithError<std::string> res;
+	try{
+		res.result = extKey.getPublicKey();
+	}catch(core::Exception& err){
+		res.error = {
+			.name = err.getName(),
+			.code = err.getCode(),
+			.description = err.getDescription(),
+			.message = err.what()
+		};
+	}catch (std::exception & err) {
+		res.error ={
+			.name = "std::Exception",
+			.message = err.what()
+		};
+	}catch (...) {
+		res.error ={
+			.name = "Unknown Exception",
+			.message = "Failed to work"
+		};
+	}
+	return res;
+}
+
+static ResultWithError<endpoint::core::Buffer> _call_ExtKey_getPrivateEncKey(const endpoint::crypto::ExtKey& extKey) noexcept {
+	ResultWithError<endpoint::core::Buffer> res;
+	try{
+		res.result = extKey.getPrivateEncKey();
+	}catch(core::Exception& err){
+		res.error = {
+			.name = err.getName(),
+			.code = err.getCode(),
+			.description = err.getDescription(),
+			.message = err.what()
+		};
+	}catch (std::exception & err) {
+		res.error ={
+			.name = "std::Exception",
+			.message = err.what()
+		};
+	}catch (...) {
+		res.error ={
+			.name = "Unknown Exception",
+			.message = "Failed to work"
+		};
+	}
+	return res;
+}
+
+static ResultWithError<std::string> _call_ExtKey_getPublicKeyAsBase58Address(const endpoint::crypto::ExtKey& extKey) noexcept {
+	ResultWithError<std::string> res;
+	try{
+		res.result = extKey.getPublicKeyAsBase58Address();
+	}catch(core::Exception& err){
+		res.error = {
+			.name = err.getName(),
+			.code = err.getCode(),
+			.description = err.getDescription(),
+			.message = err.what()
+		};
+	}catch (std::exception & err) {
+		res.error ={
+			.name = "std::Exception",
+			.message = err.what()
+		};
+	}catch (...) {
+		res.error ={
+			.name = "Unknown Exception",
+			.message = "Failed to work"
+		};
+	}
+	return res;
+}
+
+static ResultWithError<endpoint::core::Buffer> _call_ExtKey_getChainCode(const endpoint::crypto::ExtKey& extKey) noexcept{
+	ResultWithError<endpoint::core::Buffer> res;
+	try{
+		res.result = extKey.getChainCode();
+	}catch(core::Exception& err){
+		res.error = {
+			.name = err.getName(),
+			.code = err.getCode(),
+			.description = err.getDescription(),
+			.message = err.what()
+		};
+	}catch (std::exception & err) {
+		res.error ={
+			.name = "std::Exception",
+			.message = err.what()
+		};
+	}catch (...) {
+		res.error ={
+			.name = "Unknown Exception",
+			.message = "Failed to work"
+		};
+	}
+	return res;
+}
+
+static ResultWithError<bool> _call_ExtKey_verifyCompactSignatureWithHash(const endpoint::crypto::ExtKey& extKey,
+																		 const core::Buffer& message,
+																		 const core::Buffer& signature) noexcept{
+	ResultWithError<bool> res;
+	try{
+		res.result = extKey.verifyCompactSignatureWithHash(message,
+														   signature);
+	}catch(core::Exception& err){
+		res.error = {
+			.name = err.getName(),
+			.code = err.getCode(),
+			.description = err.getDescription(),
+			.message = err.what()
+		};
+	}catch (std::exception & err) {
+		res.error ={
+			.name = "std::Exception",
+			.message = err.what()
+		};
+	}catch (...) {
+		res.error ={
+			.name = "Unknown Exception",
+			.message = "Failed to work"
+		};
+	}
+	return res;
+}
+
+static ResultWithError<bool> _call_ExtKey_isPrivate(const endpoint::crypto::ExtKey& extKey) noexcept {
+	ResultWithError<bool> res;
+	try{
+		res.result = extKey.isPrivate();
+	}catch(core::Exception& err){
+		res.error = {
+			.name = err.getName(),
+			.code = err.getCode(),
+			.description = err.getDescription(),
+			.message = err.what()
+		};
+	}catch (std::exception & err) {
+		res.error ={
+			.name = "std::Exception",
+			.message = err.what()
+		};
+	}catch (...) {
+		res.error ={
+			.name = "Unknown Exception",
+			.message = "Failed to work"
+		};
+	}
+	return res;
+}
+
+}
+}
+}
+
+
+#endif//NATIVE_EXTKEY_WRAPPER_HPP

--- a/Sources/PrivMXEndpointSwiftNative/include/PrivMXUtils.hpp
+++ b/Sources/PrivMXEndpointSwiftNative/include/PrivMXUtils.hpp
@@ -34,20 +34,24 @@
 #include "privmx/endpoint/crypto/ExtKey.hpp"
 #include "privmx/endpoint/crypto/Types.hpp"
 
+
 #include "privmx/endpoint/inbox/InboxApi.hpp"
 #include "privmx/endpoint/inbox/Types.hpp"
 #include "privmx/endpoint/inbox/Events.hpp"
 #include "privmx/endpoint/inbox/InboxException.hpp"
+#include "privmx/endpoint/inbox/Constants.hpp"
 
 #include "privmx/endpoint/store/StoreApi.hpp"
 #include "privmx/endpoint/store/StoreException.hpp"
 #include "privmx/endpoint/store/Types.hpp"
 #include "privmx/endpoint/store/Events.hpp"
+#include "privmx/endpoint/store/Constants.hpp"
 
 #include "privmx/endpoint/thread/ThreadApi.hpp"
 #include "privmx/endpoint/thread/Types.hpp"
 #include "privmx/endpoint/thread/ThreadException.hpp"
 #include "privmx/endpoint/thread/Events.hpp"
+#include "privmx/endpoint/thread/Constants.hpp"
 
 #include "privmx/endpoint/event/Events.hpp"
 #include "privmx/endpoint/event/EventApi.hpp"

--- a/Sources/PrivMXEndpointSwiftNative/include/PrivMXUtils.hpp
+++ b/Sources/PrivMXEndpointSwiftNative/include/PrivMXUtils.hpp
@@ -174,8 +174,8 @@ static bool compareVectors(const FileVector& lhs, const FileVector& rhs){
 		&& l.info.storeId == r.info.storeId
 		&& l.statusCode == r.statusCode
 		&& l.authorPubKey == r.authorPubKey
-		&& l.privateMeta.stdString() == r.privateMeta.stdString()
-		&& l.publicMeta.stdString() == r.publicMeta.stdString();
+		&& l.privateMeta == r.privateMeta
+		&& l.publicMeta == r.publicMeta;
 	}
 	return res;
 }

--- a/Sources/PrivMXEndpointSwiftNative/include/PrivMXUtils.hpp
+++ b/Sources/PrivMXEndpointSwiftNative/include/PrivMXUtils.hpp
@@ -67,6 +67,12 @@ class NullApiException : std::exception{
 	}
 };
 
+static const endpoint::store::StoreDataSchema::Version CurrentStoreSchema = endpoint::store::CURRENT_STORE_DATA_SCHEMA_VERSION;
+static const endpoint::store::FileDataSchema::Version CurrentFileSchema = endpoint::store::CURRENT_FILE_DATA_SCHEMA_VERSION;
+static const endpoint::thread::ThreadDataSchema::Version CurrentThreadSchema = endpoint::thread::CURRENT_THREAD_DATA_SCHEMA_VERSION;
+static const endpoint::thread::MessageDataSchema::Version CurrentMessageSchema = endpoint::thread::CURRENT_MESSAGE_DATA_SCHEMA_VERSION;
+static const endpoint::inbox::InboxDataSchema::Version CurrentInboxSchema = endpoint::inbox::CURRENT_INBOX_DATA_SCHEMA_VERSION;
+static const endpoint::inbox::EntryDataSchema::Version CurrentEntrySchema = endpoint::inbox::CURRENT_ENTRY_DATA_SCHEMA_VERSION;
 
 using StoreFileHandle = int64_t;
 using InboxHandle [[deprecated("Use EntryHandle instead")]] = int64_t;

--- a/Sources/PrivMXEndpointSwiftNative/include/module.modulemap
+++ b/Sources/PrivMXEndpointSwiftNative/include/module.modulemap
@@ -8,6 +8,7 @@ module PrivMXEndpointSwiftNative {
 	header "NativeBackendRequesterWrapper.hpp"
 	header "NativeInboxApiWrapper.hpp"
 	header "NativeEventApiWrapper.hpp"
+	header "NativeExtKeyWrapper.hpp"
 	
     requires cplusplus17
     export *


### PR DESCRIPTION
## Additions:
- `ExtKey` wrapping `privmx::endpoint::crypto::ExtKey`
- `BIP39` wrapping `privmx::endpoint::crypto::BIP39_t`
- surfaced the (currently invisible) Current Schema constants as `privmx` members