### PR TITLE
Feat: expose scope field

### DIFF
--- a/Sources/PrivMXEndpointSwift/Core/Connection.swift
+++ b/Sources/PrivMXEndpointSwift/Core/Connection.swift
@@ -270,7 +270,7 @@ public class Connection{
 	) throws -> Void {
 		let res = api.setUserVerifier(verifier)
 		guard res.error.value == nil else {
-			throw PrivMXEndpointError.FailedSettingUserVerifier(res.error.value!)
+			throw PrivMXEndpointError.failedSettingUserVerifier(res.error.value!)
 		}
 	}
 }

--- a/Sources/PrivMXEndpointSwift/Errors/PrivMXEndpointError.swift
+++ b/Sources/PrivMXEndpointSwift/Errors/PrivMXEndpointError.swift
@@ -162,18 +162,18 @@ public enum PrivMXEndpointError : Error{
 	case failedRequestingBackend(privmx.InternalError)
 	
 	/// Failed to instantiate `EventApi`
-	case FailedInstantiatingEventApi(privmx.InternalError)
+	case failedInstantiatingEventApi(privmx.InternalError)
 	
 	/// Failed to emit a `CustomEvent`
-	case FailedEmittingCustomEvent(privmx.InternalError)
+	case failedEmittingCustomEvent(privmx.InternalError)
 
 	/// Failed to subscribe for Custom Events
-	case FailedSubscribingForCustomEvents(privmx.InternalError)
+	case failedSubscribingForCustomEvents(privmx.InternalError)
 	
 	/// Failed to subscribe for Custom Events
-	case FailedUnsubscribingFromCustomEvents(privmx.InternalError)
+	case failedUnsubscribingFromCustomEvents(privmx.InternalError)
 	
-	case FailedSettingUserVerifier(privmx.InternalError)
+	case failedSettingUserVerifier(privmx.InternalError)
 	
  	/// Failed to instantiate ExtKey
 	case failedInstantiatingExtKey(privmx.InternalError)
@@ -296,10 +296,10 @@ public enum PrivMXEndpointError : Error{
 					.failedGeneratingSymmetricKey(let err),
 					.failedVerifyingSignature(let err),
 					.failedCreatingFileHandle(let err),
-					.FailedInstantiatingEventApi(let err),
-					.FailedEmittingCustomEvent(let err),
-					.FailedSubscribingForCustomEvents(let err),
-					.FailedUnsubscribingFromCustomEvents(let err),
+					.failedInstantiatingEventApi(let err),
+					.failedEmittingCustomEvent(let err),
+					.failedSubscribingForCustomEvents(let err),
+					.failedUnsubscribingFromCustomEvents(let err),
 					.failedInstantiatingExtKey(let err),
 					.failedDerivingExtKey(let err),
 					.failedGettingPublicPartAsBase58(let err),
@@ -311,7 +311,7 @@ public enum PrivMXEndpointError : Error{
 					.failedGettingChainCode(let err),
 					.failedVerifyingCompactSignature(let err),
 					.failedCheckingIfExtKeyIsPrivate(let err),
-					.FailedSettingUserVerifier(let err),
+					.failedSettingUserVerifier(let err),
 					.failedConvertingKeyToBase58DER(let err),
 					.failedConvertingEntropyToMnemonic(let err),
 					.failedConvertingMnemonicToEntropy(let err),
@@ -401,10 +401,10 @@ public enum PrivMXEndpointError : Error{
 					.failedGeneratingSymmetricKey(let err),
 					.failedVerifyingSignature(let err),
 					.failedCreatingFileHandle(let err),
-					.FailedInstantiatingEventApi(let err),
-					.FailedEmittingCustomEvent(let err),
-					.FailedSubscribingForCustomEvents(let err),
-					.FailedUnsubscribingFromCustomEvents(let err),
+					.failedInstantiatingEventApi(let err),
+					.failedEmittingCustomEvent(let err),
+					.failedSubscribingForCustomEvents(let err),
+					.failedUnsubscribingFromCustomEvents(let err),
 					.failedInstantiatingExtKey(let err),
 					.failedDerivingExtKey(let err),
 					.failedGettingPublicPartAsBase58(let err),
@@ -416,7 +416,7 @@ public enum PrivMXEndpointError : Error{
 					.failedGettingChainCode(let err),
 					.failedVerifyingCompactSignature(let err),
 					.failedCheckingIfExtKeyIsPrivate(let err),
-					.FailedSettingUserVerifier(let err),
+					.failedSettingUserVerifier(let err),
 					.failedConvertingKeyToBase58DER(let err),
 					.failedConvertingEntropyToMnemonic(let err),
 					.failedConvertingMnemonicToEntropy(let err),
@@ -506,10 +506,10 @@ public enum PrivMXEndpointError : Error{
 					.failedGeneratingSymmetricKey(let err),
 					.failedVerifyingSignature(let err),
 					.failedCreatingFileHandle(let err),
-					.FailedInstantiatingEventApi(let err),
-					.FailedEmittingCustomEvent(let err),
-					.FailedSubscribingForCustomEvents(let err),
-					.FailedUnsubscribingFromCustomEvents(let err),
+					.failedInstantiatingEventApi(let err),
+					.failedEmittingCustomEvent(let err),
+					.failedSubscribingForCustomEvents(let err),
+					.failedUnsubscribingFromCustomEvents(let err),
 					.failedInstantiatingExtKey(let err),
 					.failedDerivingExtKey(let err),
 					.failedGettingPublicPartAsBase58(let err),
@@ -521,7 +521,7 @@ public enum PrivMXEndpointError : Error{
 					.failedGettingChainCode(let err),
 					.failedVerifyingCompactSignature(let err),
 					.failedCheckingIfExtKeyIsPrivate(let err),
-					.FailedSettingUserVerifier(let err),
+					.failedSettingUserVerifier(let err),
 					.failedConvertingKeyToBase58DER(let err),
 					.failedConvertingEntropyToMnemonic(let err),
 					.failedConvertingMnemonicToEntropy(let err),
@@ -610,10 +610,10 @@ public enum PrivMXEndpointError : Error{
 					.failedGeneratingSymmetricKey(let err),
 					.failedVerifyingSignature(let err),
 					.failedCreatingFileHandle(let err),
-					.FailedInstantiatingEventApi(let err),
-					.FailedEmittingCustomEvent(let err),
-					.FailedSubscribingForCustomEvents(let err),
-					.FailedUnsubscribingFromCustomEvents(let err),
+					.failedInstantiatingEventApi(let err),
+					.failedEmittingCustomEvent(let err),
+					.failedSubscribingForCustomEvents(let err),
+					.failedUnsubscribingFromCustomEvents(let err),
 					.failedInstantiatingExtKey(let err),
 					.failedDerivingExtKey(let err),
 					.failedGettingPublicPartAsBase58(let err),
@@ -625,7 +625,7 @@ public enum PrivMXEndpointError : Error{
 					.failedGettingChainCode(let err),
 					.failedVerifyingCompactSignature(let err),
 					.failedCheckingIfExtKeyIsPrivate(let err),
-					.FailedSettingUserVerifier(let err),
+					.failedSettingUserVerifier(let err),
 					.failedConvertingKeyToBase58DER(let err),
 					.failedConvertingEntropyToMnemonic(let err),
 					.failedConvertingMnemonicToEntropy(let err),
@@ -643,6 +643,116 @@ public enum PrivMXEndpointError : Error{
 					.failedSplittingString(let err),
 					.failedGeneratingBIP39(let err):
 				return String(err.description)
+		}
+	}
+	
+	/// Gets the Scope of the error as a String
+	///
+	///  - Returns: Scope of the error
+	public func getScope() -> String?{
+		switch self{
+			case .failedUpdatingMessage(let err),
+					.failedGettingConnectionId(let err),
+					.failedRequestingBackend(let err),
+					.failedEmittingBreakEvent(let err),
+					.failedClosingFile(let err),
+					.otherFailure(let err),
+					.failedEncrypting(let err),
+					.failedDecrypting(let err),
+					.failedSigning(let err),
+					.failedGeneratingPubKey(let err),
+					.failedGeneratingPrivKey(let err),
+					.failedConvertingKeyToWIF(let err),
+					.failedConnecting(let err),
+					.failedDisconnecting(let err),
+					.failedListingContexts(let err),
+					.failedGettingContextUsers(let err),
+					.failedCreatingThread(let err),
+					.failedGettingThread(let err),
+					.failedListingThreads(let err),
+					.failedListingMessages(let err),
+					.failedCreatingMessage(let err),
+					.failedGettingMessage(let err),
+					.failedUpdatingThread(let err),
+					.failedListingStores(let err),
+					.failedGettingStore(let err),
+					.failedCreatingStore(let err),
+					.failedGettingFile(let err),
+					.failedListingFiles(let err),
+					.failedCreatingFile(let err),
+					.failedUpdatingFile(let err),
+					.failedOpeningFile(let err),
+					.failedReadingFromFile(let err),
+					.failedSeekingInFile(let err),
+					.failedWritingToFile(let err),
+					.failedDeletingFile(let err),
+					.failedWaitingForEvent(let err),
+					.failedGettingEvent(let err),
+					.failedSubscribingForEvents(let err),
+					.failedUnsubscribingFromEvents(let err),
+					.failedDeletingThread(let err),
+					.failedDeletingMessage(let err),
+					.failedDeletingStore(let err),
+					.failedSettingCerts(let err),
+					.failedUpdatingStore(let err),
+					.failedQueryingEventHolder(let err),
+					.failedExtractingEventFromHolder(let err),
+					.failedInstantiatingEventQueue(let err),
+					.failedInstantiatingThreadApi(let err),
+					.failedInstantiatingStoreApi(let err),
+					.failedInstantiatingInboxApi(let err),
+					.failedCreatingInbox(let err),
+					.failedUpdatingInbox(let err),
+					.failedDeletingInbox(let err),
+					.failedGettingInbox(let err),
+					.failedGettingInboxPublicView(let err),
+					.failedListingInboxes(let err),
+					.failedPreparingEntry(let err),
+					.failedSendingEntry(let err),
+					.failedReadingEntry(let err),
+					.failedDeletingEntry(let err),
+					.failedListingEntries(let err),
+					.failedGeneratingSymmetricKey(let err),
+					.failedVerifyingSignature(let err),
+					.failedCreatingFileHandle(let err),
+					.failedInstantiatingEventApi(let err),
+					.failedEmittingCustomEvent(let err),
+					.failedSubscribingForCustomEvents(let err),
+					.failedUnsubscribingFromCustomEvents(let err),
+					.failedInstantiatingExtKey(let err),
+					.failedDerivingExtKey(let err),
+					.failedGettingPublicPartAsBase58(let err),
+					.failedGettingPrivatePartAsBase58(let err),
+					.failedGettingPrivateKey(let err),
+					.failedGettingPublicKey(let err),
+					.failedGettingPublicKeyAsBase58Address(let err),
+					.failedGettingPrivateEncKey(let err),
+					.failedGettingChainCode(let err),
+					.failedVerifyingCompactSignature(let err),
+					.failedCheckingIfExtKeyIsPrivate(let err),
+					.failedSettingUserVerifier(let err),
+					.failedConvertingKeyToBase58DER(let err),
+					.failedConvertingEntropyToMnemonic(let err),
+					.failedConvertingMnemonicToEntropy(let err),
+					.failedGeneratingSeedFromMnemonic(let err),
+					.failedEncodingToHex(let err),
+					.failedEncodingToBase32(let err),
+					.failedEncodingToBase64(let err),
+					.failedDecodingFromHex(let err),
+					.failedDecodingFromBase32(let err),
+					.failedDecodingFromBase64(let err),
+					.failedCheckingifStringIsHex(let err),
+					.failedCheckingifStringIsBase32(let err),
+					.failedCheckingifStringIsBase64(let err),
+					.failedTrimmingString(let err),
+					.failedSplittingString(let err),
+					.failedGeneratingBIP39(let err):
+				if let scope = err.scope.value{
+					return String(scope)
+				} else {
+					return nil
+				}
+				
 		}
 	}
 }

--- a/Sources/PrivMXEndpointSwift/Events/EventApi.swift
+++ b/Sources/PrivMXEndpointSwift/Events/EventApi.swift
@@ -37,14 +37,14 @@ public class EventApi{
 		
 		guard nil == res.error.value
 		else {
-			throw PrivMXEndpointError.FailedInstantiatingEventApi(res.error.value!)
+			throw PrivMXEndpointError.failedInstantiatingEventApi(res.error.value!)
 		}
 		guard let result = res.result.value
 		else{
 			var err = privmx.InternalError()
 			err.name = "Value error"
 			err.description = "Unexpectedly received nil result"
-			throw PrivMXEndpointError.FailedInstantiatingEventApi(err)
+			throw PrivMXEndpointError.failedInstantiatingEventApi(err)
 		}
 		return EventApi(api: result)
 	}
@@ -71,7 +71,7 @@ public class EventApi{
 			channelName,
 			eventData)
 		guard res.error.value == nil else {
-			throw PrivMXEndpointError.FailedEmittingCustomEvent(res.error.value!)
+			throw PrivMXEndpointError.failedEmittingCustomEvent(res.error.value!)
 		}
 	}
 	
@@ -88,7 +88,7 @@ public class EventApi{
 		let res = api.subscribeForCustomEvents(contextId,
 											   channelName)
 		guard res.error.value == nil else {
-			throw PrivMXEndpointError.FailedSubscribingForCustomEvents(res.error.value!)
+			throw PrivMXEndpointError.failedSubscribingForCustomEvents(res.error.value!)
 		}
 	}
 	
@@ -105,7 +105,7 @@ public class EventApi{
 		let res = api.unsubscribeFromCustomEvents(contextId,
 												  channelName)
 		guard res.error.value == nil else {
-			throw PrivMXEndpointError.FailedUnsubscribingFromCustomEvents(res.error.value!)
+			throw PrivMXEndpointError.failedUnsubscribingFromCustomEvents(res.error.value!)
 		}
 		
 	}

--- a/Sources/PrivMXEndpointSwiftNative/NativeBackendRequesterWrapper.cpp
+++ b/Sources/PrivMXEndpointSwiftNative/NativeBackendRequesterWrapper.cpp
@@ -30,6 +30,7 @@ ResultWithError<std::string> NativeBackendRequesterWrapper::backendRequest(
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -61,6 +62,7 @@ ResultWithError<std::string> NativeBackendRequesterWrapper::backendRequest(
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -98,6 +100,7 @@ ResultWithError<std::string> NativeBackendRequesterWrapper::backendRequest(
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};

--- a/Sources/PrivMXEndpointSwiftNative/NativeConnectionWrapper.cpp
+++ b/Sources/PrivMXEndpointSwiftNative/NativeConnectionWrapper.cpp
@@ -47,6 +47,7 @@ ResultWithError<std::shared_ptr<NativeConnectionWrapper>> NativeConnectionWrappe
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -82,6 +83,7 @@ ResultWithError<std::shared_ptr<NativeConnectionWrapper>> NativeConnectionWrappe
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -107,6 +109,7 @@ ResultWithError<std::nullptr_t> NativeConnectionWrapper::setCertsPath(const std:
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -133,6 +136,7 @@ ResultWithError<std::nullptr_t> NativeConnectionWrapper::disconnect(){
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -159,6 +163,7 @@ ResultWithError<ContextList> NativeConnectionWrapper::listContexts(const core::P
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -184,6 +189,7 @@ ResultWithError<UserInfoVector> NativeConnectionWrapper::getContextUsers(const s
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -209,6 +215,7 @@ ResultWithError<int64_t> NativeConnectionWrapper::getConnectionId(){
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -235,6 +242,7 @@ ResultWithError<std::nullptr_t> NativeConnectionWrapper::setUserVerifier(UserVer
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -259,6 +267,7 @@ ResultWithError<bool> CoreEventHandlerWrapper::isLibPlatformDisconnectedEvent(co
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -284,6 +293,7 @@ ResultWithError<core::LibPlatformDisconnectedEvent> CoreEventHandlerWrapper::ext
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -309,6 +319,7 @@ ResultWithError<bool> CoreEventHandlerWrapper::isLibBreakEvent(const core::Event
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -334,6 +345,7 @@ ResultWithError<core::LibBreakEvent> CoreEventHandlerWrapper::extractLibBreakEve
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -359,6 +371,7 @@ ResultWithError<bool> CoreEventHandlerWrapper::isLibConnectedEvent(const core::E
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -384,6 +397,7 @@ ResultWithError<core::LibConnectedEvent> CoreEventHandlerWrapper::extractLibConn
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -409,6 +423,7 @@ ResultWithError<bool> CoreEventHandlerWrapper::isLibDisconnectedEvent(const core
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -434,6 +449,7 @@ ResultWithError<core::LibDisconnectedEvent> CoreEventHandlerWrapper::extractLibD
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};

--- a/Sources/PrivMXEndpointSwiftNative/NativeCryptoApiWrapper.cpp
+++ b/Sources/PrivMXEndpointSwiftNative/NativeCryptoApiWrapper.cpp
@@ -29,6 +29,7 @@ ResultWithError<core::Buffer> NativeCryptoApiWrapper::generateKeySymmetric(){
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -55,6 +56,7 @@ ResultWithError<std::string> NativeCryptoApiWrapper::generatePrivateKey(const Op
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -80,6 +82,7 @@ ResultWithError<std::string> NativeCryptoApiWrapper::derivePublicKey(const std::
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -107,6 +110,7 @@ ResultWithError<core::Buffer> NativeCryptoApiWrapper::encryptDataSymmetric(const
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -134,6 +138,7 @@ ResultWithError<core::Buffer> NativeCryptoApiWrapper::decryptDataSymmetric(const
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -161,6 +166,7 @@ ResultWithError<core::Buffer> NativeCryptoApiWrapper::signData(const core::Buffe
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -187,6 +193,7 @@ ResultWithError<std::string> NativeCryptoApiWrapper::convertPEMKeyToWIFKey(const
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -214,6 +221,7 @@ ResultWithError<std::string> NativeCryptoApiWrapper::derivePrivateKey(const std:
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -241,6 +249,7 @@ ResultWithError<std::string> NativeCryptoApiWrapper::derivePrivateKey2(const std
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -272,6 +281,7 @@ ResultWithError<bool> NativeCryptoApiWrapper::verifySignature(
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -297,6 +307,7 @@ ResultWithError<std::string> NativeCryptoApiWrapper::convertPGPAsn1KeyToBase58DE
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -325,6 +336,7 @@ ResultWithError<endpoint::crypto::BIP39_t> NativeCryptoApiWrapper::generateBip39
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -352,6 +364,7 @@ ResultWithError<endpoint::crypto::BIP39_t> NativeCryptoApiWrapper::fromMnemonic(
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -379,6 +392,7 @@ ResultWithError<endpoint::crypto::BIP39_t> NativeCryptoApiWrapper::fromEntropy(c
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -404,6 +418,7 @@ ResultWithError<std::string> NativeCryptoApiWrapper::entropyToMnemonic(const end
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -429,6 +444,7 @@ ResultWithError<endpoint::core::Buffer> NativeCryptoApiWrapper::mnemonicToEntrop
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -457,6 +473,7 @@ ResultWithError<endpoint::core::Buffer> NativeCryptoApiWrapper::mnemonicToSeed(c
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};

--- a/Sources/PrivMXEndpointSwiftNative/NativeEventApiWrapper.cpp
+++ b/Sources/PrivMXEndpointSwiftNative/NativeEventApiWrapper.cpp
@@ -26,6 +26,7 @@ ResultWithError<NativeEventApiWrapper> NativeEventApiWrapper::create(NativeConne
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -58,6 +59,7 @@ ResultWithError<std::nullptr_t> NativeEventApiWrapper::emitEvent(const std::stri
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -85,6 +87,7 @@ ResultWithError<std::nullptr_t> NativeEventApiWrapper::subscribeForCustomEvents(
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -112,6 +115,7 @@ ResultWithError<std::nullptr_t> NativeEventApiWrapper::unsubscribeFromCustomEven
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};

--- a/Sources/PrivMXEndpointSwiftNative/NativeEventQueueWrapper.cpp
+++ b/Sources/PrivMXEndpointSwiftNative/NativeEventQueueWrapper.cpp
@@ -25,6 +25,7 @@ ResultWithError<NativeEventQueueWrapper> NativeEventQueueWrapper::getInstance(){
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -50,6 +51,7 @@ ResultWithError<core::EventHolder> NativeEventQueueWrapper::waitEvent(){
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -75,6 +77,7 @@ ResultWithError<std::optional<core::EventHolder>> NativeEventQueueWrapper::getEv
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -100,6 +103,7 @@ ResultWithError<nullptr_t> NativeEventQueueWrapper::emitBreakEvent(){
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};

--- a/Sources/PrivMXEndpointSwiftNative/NativeInboxApiWrapper.cpp
+++ b/Sources/PrivMXEndpointSwiftNative/NativeInboxApiWrapper.cpp
@@ -30,6 +30,7 @@ ResultWithError<NativeInboxApiWrapper> NativeInboxApiWrapper::create(NativeConne
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -67,6 +68,7 @@ ResultWithError<std::string> NativeInboxApiWrapper::createInbox(const std::strin
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -110,6 +112,7 @@ ResultWithError<nullptr_t> NativeInboxApiWrapper::updateInbox(const std::string&
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -135,6 +138,7 @@ ResultWithError<inbox::Inbox> NativeInboxApiWrapper::getInbox(const std::string 
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -162,6 +166,7 @@ ResultWithError<InboxList> NativeInboxApiWrapper::listInboxes(const std::string&
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -186,6 +191,7 @@ ResultWithError<inbox::InboxPublicView> NativeInboxApiWrapper::getInboxPublicVie
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -211,6 +217,7 @@ ResultWithError<nullptr_t> NativeInboxApiWrapper::deleteInbox(const std::string 
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -242,6 +249,7 @@ ResultWithError<EntryHandle> NativeInboxApiWrapper::prepareEntry(const std::stri
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -268,6 +276,7 @@ ResultWithError<nullptr_t> NativeInboxApiWrapper::sendEntry(const EntryHandle en
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -293,6 +302,7 @@ ResultWithError<inbox::InboxEntry> NativeInboxApiWrapper::readEntry(const std::s
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -320,6 +330,7 @@ ResultWithError<InboxEntryList> NativeInboxApiWrapper::listEntries(const std::st
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -345,6 +356,7 @@ ResultWithError<nullptr_t> NativeInboxApiWrapper::deleteEntry(const std::string&
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -374,6 +386,7 @@ ResultWithError<InboxFileHandle> NativeInboxApiWrapper::createFileHandle(const e
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -403,6 +416,7 @@ ResultWithError<nullptr_t> NativeInboxApiWrapper::writeToFile(const EntryHandle 
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -428,6 +442,7 @@ ResultWithError<InboxFileHandle> NativeInboxApiWrapper::openFile(const std::stri
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -455,6 +470,7 @@ ResultWithError<core::Buffer> NativeInboxApiWrapper::readFromFile(const InboxFil
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -482,6 +498,7 @@ ResultWithError<nullptr_t> NativeInboxApiWrapper::seekInFile(const InboxFileHand
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -507,6 +524,7 @@ ResultWithError<std::string> NativeInboxApiWrapper::closeFile(const InboxFileHan
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -532,6 +550,7 @@ ResultWithError<nullptr_t> NativeInboxApiWrapper::subscribeForInboxEvents(){
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -557,6 +576,7 @@ ResultWithError<nullptr_t> NativeInboxApiWrapper::unsubscribeFromInboxEvents(){
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -582,6 +602,7 @@ ResultWithError<nullptr_t> NativeInboxApiWrapper::subscribeForEntryEvents(const 
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -607,6 +628,7 @@ ResultWithError<nullptr_t> NativeInboxApiWrapper::unsubscribeFromEntryEvents(con
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -633,6 +655,7 @@ ResultWithError<bool> InboxEventHandler::isInboxCreatedEvent(const endpoint::cor
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -659,6 +682,7 @@ ResultWithError<endpoint::inbox::InboxCreatedEvent> InboxEventHandler::extractIn
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -684,6 +708,7 @@ ResultWithError<bool> InboxEventHandler::isInboxUpdatedEvent(const endpoint::cor
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -709,6 +734,7 @@ ResultWithError<endpoint::inbox::InboxUpdatedEvent> InboxEventHandler::extractIn
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -734,6 +760,7 @@ ResultWithError<bool> InboxEventHandler::isInboxDeletedEvent(const endpoint::cor
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -759,6 +786,7 @@ ResultWithError<endpoint::inbox::InboxDeletedEvent> InboxEventHandler::extractIn
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -784,6 +812,7 @@ ResultWithError<bool> InboxEventHandler::isInboxEntryCreatedEvent(const endpoint
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -809,6 +838,7 @@ ResultWithError<endpoint::inbox::InboxEntryCreatedEvent> InboxEventHandler::extr
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -834,6 +864,7 @@ ResultWithError<bool> InboxEventHandler::isInboxEntryDeletedEvent(const endpoint
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -859,6 +890,7 @@ ResultWithError<endpoint::inbox::InboxEntryDeletedEvent> InboxEventHandler::extr
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};

--- a/Sources/PrivMXEndpointSwiftNative/NativeStoreApiWrapper.cpp
+++ b/Sources/PrivMXEndpointSwiftNative/NativeStoreApiWrapper.cpp
@@ -27,6 +27,7 @@ ResultWithError<NativeStoreApiWrapper> NativeStoreApiWrapper::create(NativeConne
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -53,6 +54,7 @@ ResultWithError<StoreList> NativeStoreApiWrapper::listStores(const std::string& 
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -78,6 +80,7 @@ ResultWithError<store::Store> NativeStoreApiWrapper::getStore(const std::string 
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -113,6 +116,7 @@ ResultWithError<std::string> NativeStoreApiWrapper::createStore(const std::strin
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -154,6 +158,7 @@ ResultWithError<std::nullptr_t> NativeStoreApiWrapper::updateStore(const std::st
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -179,6 +184,7 @@ ResultWithError<store::File> NativeStoreApiWrapper::getFile(const std::string &f
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -205,6 +211,7 @@ ResultWithError<FileList> NativeStoreApiWrapper::listFiles(const std::string& st
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -233,6 +240,7 @@ ResultWithError<StoreFileHandle> NativeStoreApiWrapper::createFile(const std::st
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -261,6 +269,7 @@ ResultWithError<StoreFileHandle> NativeStoreApiWrapper::updateFile(const std::st
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -288,6 +297,7 @@ ResultWithError<std::nullptr_t> NativeStoreApiWrapper::updateFileMeta(const std:
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -313,6 +323,7 @@ ResultWithError<StoreFileHandle> NativeStoreApiWrapper::openFile(const std::stri
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -339,6 +350,7 @@ ResultWithError<core::Buffer> NativeStoreApiWrapper::readFromFile(StoreFileHandl
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -365,6 +377,7 @@ ResultWithError<std::nullptr_t> NativeStoreApiWrapper::writeToFile(StoreFileHand
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -390,6 +403,7 @@ ResultWithError<std::nullptr_t> NativeStoreApiWrapper::deleteFile(const std::str
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -416,6 +430,7 @@ ResultWithError<std::nullptr_t> NativeStoreApiWrapper::seekInFile(StoreFileHandl
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -441,6 +456,7 @@ ResultWithError<std::string> NativeStoreApiWrapper::closeFile(StoreFileHandle ha
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -466,6 +482,7 @@ ResultWithError<std::nullptr_t> NativeStoreApiWrapper::deleteStore(const std::st
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -491,6 +508,7 @@ ResultWithError<nullptr_t> NativeStoreApiWrapper::subscribeForStoreEvents(){
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -515,6 +533,7 @@ ResultWithError<nullptr_t> NativeStoreApiWrapper::unsubscribeFromStoreEvents(){
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -539,6 +558,7 @@ ResultWithError<nullptr_t> NativeStoreApiWrapper::subscribeForFileEvents(const s
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -563,6 +583,7 @@ ResultWithError<nullptr_t> NativeStoreApiWrapper::unsubscribeFromFileEvents(cons
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -588,6 +609,7 @@ ResultWithError<bool> StoreEventHandler::isStoreCreatedEvent(const core::EventHo
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -613,6 +635,7 @@ ResultWithError<store::StoreCreatedEvent> StoreEventHandler::extractStoreCreated
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -638,6 +661,7 @@ ResultWithError<bool> StoreEventHandler::isStoreUpdatedEvent(const core::EventHo
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -663,6 +687,7 @@ ResultWithError<store::StoreUpdatedEvent> StoreEventHandler::extractStoreUpdated
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -688,6 +713,7 @@ ResultWithError<bool> StoreEventHandler::isStoreDeletedEvent(const core::EventHo
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -713,6 +739,7 @@ ResultWithError<store::StoreDeletedEvent> StoreEventHandler::extractStoreDeleted
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -738,6 +765,7 @@ ResultWithError<bool> StoreEventHandler::isStoreStatsChangedEvent(const core::Ev
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -763,6 +791,7 @@ ResultWithError<store::StoreStatsChangedEvent> StoreEventHandler::extractStoreSt
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -788,6 +817,7 @@ ResultWithError<bool> StoreEventHandler::isStoreFileCreatedEvent(const core::Eve
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -813,6 +843,7 @@ ResultWithError<store::StoreFileCreatedEvent> StoreEventHandler::extractStoreFil
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -838,6 +869,7 @@ ResultWithError<bool> StoreEventHandler::isStoreFileUpdatedEvent(const core::Eve
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -863,6 +895,7 @@ ResultWithError<store::StoreFileUpdatedEvent> StoreEventHandler::extractStoreFil
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -888,6 +921,7 @@ ResultWithError<bool> StoreEventHandler::isStoreFileDeletedEvent(const core::Eve
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -913,6 +947,7 @@ ResultWithError<store::StoreFileDeletedEvent> StoreEventHandler::extractStoreFil
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};

--- a/Sources/PrivMXEndpointSwiftNative/NativeThreadApiWrapper.cpp
+++ b/Sources/PrivMXEndpointSwiftNative/NativeThreadApiWrapper.cpp
@@ -26,6 +26,7 @@ ResultWithError<NativeThreadApiWrapper> NativeThreadApiWrapper::create(NativeCon
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -61,6 +62,7 @@ ResultWithError<std::string> NativeThreadApiWrapper::createThread(const std::str
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -87,6 +89,7 @@ ResultWithError<thread::Thread> NativeThreadApiWrapper::getThread(const std::str
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -115,6 +118,7 @@ ResultWithError<ThreadList> NativeThreadApiWrapper::listThreads(const std::strin
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -141,6 +145,7 @@ ResultWithError<MessageList> NativeThreadApiWrapper::listMessages(const std::str
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -169,6 +174,7 @@ ResultWithError<std::string> NativeThreadApiWrapper::sendMessage(const std::stri
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -194,6 +200,7 @@ ResultWithError<std::nullptr_t> NativeThreadApiWrapper::deleteThread(const std::
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -219,6 +226,7 @@ ResultWithError<std::nullptr_t> NativeThreadApiWrapper::deleteMessage(const std:
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -244,6 +252,7 @@ ResultWithError<thread::Message> NativeThreadApiWrapper::getMessage(const std::s
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -285,6 +294,7 @@ ResultWithError<std::nullptr_t> NativeThreadApiWrapper::updateThread(const std::
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -317,6 +327,7 @@ ResultWithError<nullptr_t> NativeThreadApiWrapper::updateMessage(const std::stri
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -343,6 +354,7 @@ ResultWithError<nullptr_t> NativeThreadApiWrapper::subscribeForThreadEvents(){
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -368,6 +380,7 @@ ResultWithError<nullptr_t> NativeThreadApiWrapper::unsubscribeFromThreadEvents()
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -393,6 +406,7 @@ ResultWithError<nullptr_t> NativeThreadApiWrapper::subscribeForMessageEvents(con
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -418,6 +432,7 @@ ResultWithError<nullptr_t> NativeThreadApiWrapper::unsubscribeFromMessageEvents(
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -443,6 +458,7 @@ ResultWithError<bool> ThreadEventHandler::isThreadCreatedEvent(const core::Event
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -468,6 +484,7 @@ ResultWithError<thread::ThreadCreatedEvent> ThreadEventHandler::extractThreadCre
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -493,6 +510,7 @@ ResultWithError<bool> ThreadEventHandler::isThreadUpdatedEvent(const core::Event
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -518,6 +536,7 @@ ResultWithError<thread::ThreadUpdatedEvent> ThreadEventHandler::extractThreadUpd
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -543,6 +562,7 @@ ResultWithError<bool> ThreadEventHandler::isThreadDeletedEvent(const core::Event
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -568,6 +588,7 @@ ResultWithError<thread::ThreadDeletedEvent> ThreadEventHandler::extractThreadDel
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -593,6 +614,7 @@ ResultWithError<bool> ThreadEventHandler::isThreadNewMessageEvent(const core::Ev
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -618,6 +640,7 @@ ResultWithError<thread::ThreadNewMessageEvent> ThreadEventHandler::extractThread
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -643,6 +666,7 @@ ResultWithError<bool> ThreadEventHandler::isThreadDeletedMessageEvent(const core
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -669,6 +693,7 @@ ResultWithError<bool> ThreadEventHandler::isThreadMessageDeletedEvent(const core
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -694,6 +719,7 @@ ResultWithError<bool> ThreadEventHandler::isThreadMessageUpdatedEvent(const core
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -719,6 +745,7 @@ ResultWithError<thread::ThreadMessageDeletedEvent> ThreadEventHandler::extractTh
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -744,6 +771,7 @@ ResultWithError<thread::ThreadMessageDeletedEvent> ThreadEventHandler::extractTh
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -768,6 +796,7 @@ ResultWithError<thread::ThreadMessageUpdatedEvent> ThreadEventHandler::extractTh
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -793,6 +822,7 @@ ResultWithError<bool> ThreadEventHandler::isThreadStatsEvent(const core::EventHo
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -818,6 +848,7 @@ ResultWithError<thread::ThreadStatsChangedEvent> ThreadEventHandler::extractThre
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};

--- a/Sources/PrivMXEndpointSwiftNative/include/NativeExtKeyWrapper.hpp
+++ b/Sources/PrivMXEndpointSwiftNative/include/NativeExtKeyWrapper.hpp
@@ -25,6 +25,7 @@ static ResultWithError<endpoint::crypto::ExtKey> _call_ExtKey_fromSeed(const cor
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -50,6 +51,7 @@ static ResultWithError<endpoint::crypto::ExtKey> _call_ExtKey_fromBase58(const s
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -75,6 +77,7 @@ static ResultWithError<endpoint::crypto::ExtKey> _call_ExtKey_generateRandom() n
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -101,6 +104,7 @@ static ResultWithError<endpoint::crypto::ExtKey> _call_ExtKey_derive(const endpo
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -127,6 +131,7 @@ static ResultWithError<endpoint::crypto::ExtKey> _call_ExtKey_deriveHardened(con
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -152,6 +157,7 @@ static ResultWithError<std::string> _call_ExtKey_getPrivatePartAsBase58(const en
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -177,6 +183,7 @@ static ResultWithError<std::string> _call_ExtKey_getPublicPartAsBase58(const end
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -202,6 +209,7 @@ static ResultWithError<std::string> _call_ExtKey_getPrivateKey(const endpoint::c
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -227,6 +235,7 @@ static ResultWithError<std::string> _call_ExtKey_getPublicKey(const endpoint::cr
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -252,6 +261,7 @@ static ResultWithError<endpoint::core::Buffer> _call_ExtKey_getPrivateEncKey(con
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -277,6 +287,7 @@ static ResultWithError<std::string> _call_ExtKey_getPublicKeyAsBase58Address(con
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -302,6 +313,7 @@ static ResultWithError<endpoint::core::Buffer> _call_ExtKey_getChainCode(const e
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -330,6 +342,7 @@ static ResultWithError<bool> _call_ExtKey_verifyCompactSignatureWithHash(const e
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -355,6 +368,7 @@ static ResultWithError<bool> _call_ExtKey_isPrivate(const endpoint::crypto::ExtK
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};

--- a/Sources/PrivMXEndpointSwiftNative/include/PrivMXUtils.hpp
+++ b/Sources/PrivMXEndpointSwiftNative/include/PrivMXUtils.hpp
@@ -121,6 +121,10 @@ struct InternalError{
 	 * Error Code, if it was provided
 	 */
 	std::optional<unsigned int> code;
+	/**
+	 * Error Scope, if it was provided
+	 */
+	std::optional<std::string> scope;
 };
 
 /**
@@ -223,6 +227,7 @@ static ResultWithError<std::string> _call_Hex_encode(const endpoint::core::Buffe
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -248,6 +253,7 @@ static ResultWithError<endpoint::core::Buffer> _call_Hex_decode(const std::strin
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -273,6 +279,7 @@ static ResultWithError<bool> _call_Hex_is(const std::string& data) noexcept{
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -298,6 +305,7 @@ static ResultWithError<std::string> _call_Base32_encode(const endpoint::core::Bu
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -323,6 +331,7 @@ static ResultWithError<endpoint::core::Buffer> _call_Base32_decode(const std::st
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -348,6 +357,7 @@ static ResultWithError<bool> _call_Base32_is(const std::string& data) noexcept{
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -373,6 +383,7 @@ static ResultWithError<std::string> _call_Base64_encode(const endpoint::core::Bu
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -398,6 +409,7 @@ static ResultWithError<endpoint::core::Buffer> _call_Base64_decode(const std::st
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -423,6 +435,7 @@ static ResultWithError<bool> _call_Base64_is(const std::string& data) noexcept{
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -448,6 +461,7 @@ static ResultWithError<std::string> _call_Utils_trim(const std::string& data) no
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -475,6 +489,7 @@ static ResultWithError<StringVector> _call_Utils_split(std::string data ,
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -500,6 +515,7 @@ static ResultWithError<std::nullptr_t> _call_Utils_ltrim(std::string& data) noex
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};
@@ -525,6 +541,7 @@ static ResultWithError<std::nullptr_t> _call_Utils_rtrim(std::string& data) noex
 		res.error = {
 			.name = err.getName(),
 			.code = err.getCode(),
+			.scope = err.getScope(),
 			.description = err.getDescription(),
 			.message = err.what()
 		};


### PR DESCRIPTION
## Additions:
- `getScope()` on `PrivmxEndpointError`
 
## Modifications:
- Added `scope` field to `privmx.InternalError`
- error cases start lowercase (EventApi - related)